### PR TITLE
refactor: cleanup database opening logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "discord.js": "^11.3.2",
     "discord.js-commando": "^0.10.0",
     "dotenv": "^8.2.0",
-    "mkdirp": "^0.5.1",
     "node-opus": "^0.3.3",
     "sqlite": "^2.9.3",
     "uws": "^100.0.1",

--- a/src/Makibot.ts
+++ b/src/Makibot.ts
@@ -1,14 +1,11 @@
 import * as Commando from 'discord.js-commando';
-import * as sqlite from 'sqlite';
 import * as path from 'path';
-import * as fs from 'fs';
 import ConfigSchema from './ConfigSchema';
 import { Message } from 'discord.js';
 import PinService from './hooks/pin';
-import { config as XDG_CONFIG } from 'xdg-basedir';
-import * as mkdirp from 'mkdirp';
 import RosterService from './hooks/roster';
 import VerifyService from './hooks/verify';
+import { getDatabase } from './settings';
 
 export default class Makibot extends Commando.CommandoClient {
 
@@ -34,8 +31,7 @@ export default class Makibot extends Commando.CommandoClient {
         this.on('ready', () => console.log(`Logged in successfully as ${this.user.tag}.`));
 
         this.once('ready', () => {
-            this.settingsFile()
-                .then(file => sqlite.open(file))
+            getDatabase()
                 .then(db => this.setProvider(new Commando.SQLiteProvider(db)))
                 .then(() => {
                     // Reload presence using database values.
@@ -56,26 +52,6 @@ export default class Makibot extends Commando.CommandoClient {
         });
 
         this.login(ConfigSchema.token);
-    }
-
-    private settingsFile(): Promise<string> {
-        // This is what we want to return.
-        let configFile = path.join(XDG_CONFIG, 'clank', 'settings.db');
-
-        // But, hold on! Because it may be that the parent directory does not exist.
-        let configDir = path.dirname(configFile);
-        return new Promise((resolve, reject) => {
-            if (!fs.existsSync(configDir)) {
-                // I told you! Let's fix this.
-                mkdirp(configDir, err => {
-                    if (err) reject(err);
-                    else resolve(configFile);
-                });
-            } else {
-                // Ok, just let it go.
-                resolve(configFile);
-            }
-        });
     }
 
     shutdown() {

--- a/src/Makibot.ts
+++ b/src/Makibot.ts
@@ -1,61 +1,61 @@
-import * as Commando from 'discord.js-commando';
-import * as path from 'path';
-import ConfigSchema from './ConfigSchema';
-import { Message } from 'discord.js';
-import PinService from './hooks/pin';
-import RosterService from './hooks/roster';
-import VerifyService from './hooks/verify';
-import { getDatabase } from './settings';
+import path from "path";
+
+import Commando from "discord.js-commando";
+
+import ConfigSchema from "./ConfigSchema";
+import { getDatabase } from "./settings";
+import PinService from "./hooks/pin";
+import RosterService from "./hooks/roster";
+import VerifyService from "./hooks/verify";
 
 export default class Makibot extends Commando.CommandoClient {
+  public constructor() {
+    super({
+      commandPrefix: "!",
+      owner: ConfigSchema.owner,
+      disableEveryone: true,
+      unknownCommandResponse: false,
+    });
 
-    public constructor() {
-        super({
-            commandPrefix: '!',
-            owner: ConfigSchema.owner,
-            disableEveryone: true,
-            unknownCommandResponse: false
-        });
+    this.registry.registerDefaultTypes();
+    this.registry.registerGroups([
+      ["admin", "Administración"],
+      ["fun", "Entretenimiento"],
+      ["utiles", "Utilidad"],
+    ]);
+    this.registry.registerCommandsIn({
+      dirname: path.join(__dirname, "commands"),
+      filter: /^([^\.].*)\.ts$/,
+    });
 
-        this.registry.registerDefaultTypes();
-        this.registry.registerGroups([
-            ['admin', 'Administración'],
-            ['fun', 'Entretenimiento'],
-            ['utiles', 'Utilidad']
-        ]);
-        this.registry.registerCommandsIn({
-            dirname: path.join(__dirname, 'commands'),
-            filter: /^([^\.].*)\.ts$/
-        });
+    this.on("ready", () => console.log(`Logged in successfully as ${this.user.tag}.`));
 
-        this.on('ready', () => console.log(`Logged in successfully as ${this.user.tag}.`));
+    this.once("ready", () => {
+      getDatabase()
+        .then(db => this.setProvider(new Commando.SQLiteProvider(db)))
+        .then(() => {
+          // Reload presence using database values.
+          this.user.setPresence({
+            status: this.settings.get("BotPresence", "online"),
+            game: { name: this.settings.get("BotActivity", null) },
+          });
 
-        this.once('ready', () => {
-            getDatabase()
-                .then(db => this.setProvider(new Commando.SQLiteProvider(db)))
-                .then(() => {
-                    // Reload presence using database values.
-                    this.user.setPresence({
-                        status: this.settings.get('BotPresence', 'online'),
-                        game: { name: this.settings.get('BotActivity', null) }
-                    });
+          // Register hooks.
+          var pin = new PinService(this);
+          var roster = new RosterService(this);
 
-                    // Register hooks.
-                    var pin = new PinService(this);
-                    var roster = new RosterService(this);
+          if (process.env.VERIFY_CHANNEL && process.env.VERIFY_ROLE) {
+            var verify = new VerifyService(this);
+          }
+        })
+        .catch(console.log);
+    });
 
-                    if (process.env.VERIFY_CHANNEL && process.env.VERIFY_ROLE) {
-                        var verify = new VerifyService(this);
-                    }
-                })
-                .catch(console.log);
-        });
+    this.login(ConfigSchema.token);
+  }
 
-        this.login(ConfigSchema.token);
-    }
-
-    shutdown() {
-        console.log('The bot was asked to shutdown. Good night!');
-        this.destroy();
-    }
+  shutdown() {
+    console.log("The bot was asked to shutdown. Good night!");
+    this.destroy();
+  }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,44 @@
+import { stat, mkdir } from "fs";
+import { dirname, resolve } from "path";
+
+import { Database, open as sqliteOpen } from "sqlite";
+import { config as XDG_CONFIG } from "xdg-basedir";
+
+function assertDirectoryExists(dir: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    stat(dir, (statErr, stats) => {
+      if (statErr) {
+        if (statErr.code === "ENOENT") {
+          // The directory does not exist. This is a valid case.
+          mkdir(dir, { recursive: true }, mkdirErr => {
+            if (mkdirErr) {
+              reject(mkdirErr);
+            } else {
+              resolve();
+            }
+          });
+        } else {
+          // We don't know which kind of error this is.
+          reject(statErr);
+        }
+      } else {
+        if (stats.isDirectory()) {
+          resolve();
+        } else {
+          reject(`${dir} exists but it is not a directory`);
+        }
+      }
+    });
+  });
+}
+
+export async function getDatabase(): Promise<Database> {
+  // The final location where the database file will be created.
+  const dbFile = resolve(XDG_CONFIG, "clank", "settings.db");
+
+  // Need to make sure first that the file exists.
+  const pathToDbFile = dirname(dbFile);
+  await assertDirectoryExists(pathToDbFile);
+
+  return sqliteOpen(dbFile);
+}


### PR DESCRIPTION
This PR refactors the logic that asserts that the directory for the database exists into a separate file. Additionally, because `fs.mkdir` from NodeJS standard library gained a recursive option in NodeJS 10, drops the `mkdirp` dependency.

database.ts is a new file that exports a function that will return a valid pointer to the SQLite database to be used by the bot.