### PR TITLE
chore(deps): downgrade @types/node to 10.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.1.tgz",
-      "integrity": "sha512-hx6zWtudh3Arsbl3cXay+JnkvVgCKzCWKv42C9J01N2T2np4h8w5X8u6Tpz5mj38kE3M9FM0Pazx8vKFFMnjLQ==",
+      "version": "10.17.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
+      "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "description": "Discord bot for the makigas server",
   "devDependencies": {
-    "@types/node": "13.1.1",
+    "@types/node": "^10.17.13",
     "prettier": "^1.19.1",
     "rimraf": "^3.0.0",
     "ts-node": "^8.6.2",


### PR DESCRIPTION
I don't remember when I did upgrade it to 13.x, but because Clank is
using Node 10, it doesn't make any sense to have a @types/node version
mismatching the node version in use.

Closes #62 

<!-- 👋 Thank you for contributing code to this project

To guarantee success for your pull request, use the following template.
Make sure the checklis passes. Otherwise, your pull request may be
rejected. By sending a pull request, you agree you have read this
document, as well as CONTRIBUTING.md and CODE_OF_CONDUCT.md. Thank you! -->

Add your PR description here.

## Checklist

- [ ] Given that this code will have to be maintained by someone else in
      the future that it's not me, my code is clean, concise and it has
      been tested.
- [ ] There is an issue tracking this feature and I've linked to it in my
      PR, where a discussion may have been held, because I'd rather not
      add surprise features without discussing whether they fit or not
      in the project scope before.
- [ ] The files conforming this PR have been formatted with prettier
      so that they follow the code styleguide.
