### PR TITLE
feat: automatic moderation actions

### DIFF
--- a/src/Makibot.ts
+++ b/src/Makibot.ts
@@ -7,6 +7,7 @@ import { getDatabase } from "./settings";
 import PinService from "./hooks/pin";
 import RosterService from "./hooks/roster";
 import VerifyService from "./hooks/verify";
+import WarnService from "./hooks/warn";
 
 export default class Makibot extends Commando.CommandoClient {
   public constructor() {
@@ -43,6 +44,7 @@ export default class Makibot extends Commando.CommandoClient {
           // Register hooks.
           var pin = new PinService(this);
           var roster = new RosterService(this);
+          var warn = new WarnService(this);
 
           if (process.env.VERIFY_CHANNEL && process.env.VERIFY_ROLE) {
             var verify = new VerifyService(this);

--- a/src/Makibot.ts
+++ b/src/Makibot.ts
@@ -20,6 +20,7 @@ export default class Makibot extends Commando.CommandoClient {
     this.registry.registerDefaultTypes();
     this.registry.registerGroups([
       ["admin", "Administración"],
+      ["moderation", "Moderación"],
       ["utiles", "Utilidad"],
     ]);
     this.registry.registerCommandsIn({

--- a/src/commands/moderation/warn.ts
+++ b/src/commands/moderation/warn.ts
@@ -1,8 +1,9 @@
-import { User, RichEmbedOptions, GuildMember, GuildChannel, TextChannel } from "discord.js";
+import { User, GuildMember } from "discord.js";
 import Commando from "discord.js-commando";
 
 import Makibot from "../../Makibot";
 import applyWarn from "../../lib/warn";
+import Server from "../../lib/server";
 
 interface WarnCommandArguments {
   target: User;
@@ -35,8 +36,9 @@ export = class WarnCommand extends Commando.Command {
   }
 
   private isMod(user: GuildMember): boolean {
-    const modsRoleName = process.env.MODS_ROLE || "mods";
-    return user.roles.exists("name", modsRoleName);
+    const server = new Server(user.guild);
+    const modRole = server.modsRole;
+    return modRole.members.exists("id", user.id);
   }
 
   run(msg: Commando.CommandMessage, args: WarnCommandArguments) {

--- a/src/commands/moderation/warn.ts
+++ b/src/commands/moderation/warn.ts
@@ -1,4 +1,4 @@
-import { User, GuildMember } from "discord.js";
+import { User, Message } from "discord.js";
 import Commando from "discord.js-commando";
 
 import Makibot from "../../Makibot";
@@ -35,19 +35,16 @@ export = class WarnCommand extends Commando.Command {
     });
   }
 
-  private isMod(user: GuildMember): boolean {
-    const server = new Server(user.guild);
+  run(msg: Commando.CommandMessage, { reason, target }: WarnCommandArguments): Promise<Message[]> {
+    const author = msg.member;
+    const server = new Server(msg.guild);
     const modRole = server.modsRole;
-    return modRole.members.exists("id", user.id);
-  }
-
-  run(msg: Commando.CommandMessage, args: WarnCommandArguments) {
-    if (!this.isMod(msg.member)) {
+    if (!modRole.members.exists("id", author.id) && modRole.members.exists("id", target.id)) {
       return Promise.resolve([]);
     }
 
     // The issuer of the command is authorized to warn this user.
-    applyWarn(msg.guild, { user: args.target, reason: args.reason });
+    applyWarn(msg.guild, { user: target, reason: reason });
 
     return Promise.resolve([]);
   }

--- a/src/commands/moderation/warn.ts
+++ b/src/commands/moderation/warn.ts
@@ -2,18 +2,12 @@ import { User, RichEmbedOptions, GuildMember, GuildChannel, TextChannel } from "
 import Commando from "discord.js-commando";
 
 import Makibot from "../../Makibot";
+import applyWarn from "../../lib/warn";
 
 interface WarnCommandArguments {
   target: User;
   reason: string;
 }
-
-const messages = [
-  "si sigues comportándote así en este servidor, serás echado",
-  "desde moderación encontramos inapropiada esa actitud",
-  "¿te has leído las normas de este servidor? No lo tenemos claro",
-  "en este servidor no se tolera ese tipo de comportamiento",
-];
 
 export = class WarnCommand extends Commando.Command {
   constructor(client: Makibot) {
@@ -50,40 +44,8 @@ export = class WarnCommand extends Commando.Command {
       return Promise.resolve([]);
     }
 
-    // Get the member behind this user.
-    const memberToWarn = msg.guild.member(args.target);
-
-    // Warn this user.
-    const warnRoleName = process.env.WARN_ROLE || "warn";
-    const warnRole = msg.guild.roles.find("name", warnRoleName);
-    memberToWarn.addRole(warnRole);
-
-    // Remove this user from the helpers role if they were.
-    const helperRoleName = process.env.HELPER_ROLE || "helpers";
-    const helperRole = msg.guild.roles.find("name", helperRoleName);
-    memberToWarn.removeRole(helperRole);
-
-    // Send a message to the public modlog.
-    const embed: RichEmbedOptions = {
-      title: `Se llamó la atención a ${memberToWarn.user.tag}`,
-      color: 16545847,
-      description: args.reason ? `**Razón**: ${args.reason}` : null,
-      author: {
-        name: memberToWarn.user.tag,
-        icon_url: memberToWarn.user.avatarURL,
-      },
-      footer: {
-        text: "Mensaje de moderación automático",
-      },
-    };
-
-    const modlogChannelName = process.env.PUBLIC_MODLOG_CHANNEL || "modlog";
-    const modlogChannel = msg.guild.channels.find("name", modlogChannelName);
-    if (modlogChannel.type === "text") {
-      const randomMessage = messages[Math.floor(Math.random() * messages.length)];
-      const message = `<@${memberToWarn.id}>: ${randomMessage}`;
-      (<TextChannel>modlogChannel).send(message, { embed });
-    }
+    // The issuer of the command is authorized to warn this user.
+    applyWarn(msg.guild, { user: args.target, reason: args.reason });
 
     return Promise.resolve([]);
   }

--- a/src/commands/moderation/warn.ts
+++ b/src/commands/moderation/warn.ts
@@ -39,7 +39,9 @@ export = class WarnCommand extends Commando.Command {
     const author = msg.member;
     const server = new Server(msg.guild);
     const modRole = server.modsRole;
-    if (!modRole.members.exists("id", author.id) && modRole.members.exists("id", target.id)) {
+    const authorIsMod = modRole.members.exists("id", author.id);
+    const targetIsMod = modRole.members.exists("id", target.id);
+    if (!authorIsMod || targetIsMod) {
       return Promise.resolve([]);
     }
 

--- a/src/commands/moderation/warn.ts
+++ b/src/commands/moderation/warn.ts
@@ -1,0 +1,90 @@
+import { User, RichEmbedOptions, GuildMember, GuildChannel, TextChannel } from "discord.js";
+import Commando from "discord.js-commando";
+
+import Makibot from "../../Makibot";
+
+interface WarnCommandArguments {
+  target: User;
+  reason: string;
+}
+
+const messages = [
+  "si sigues comportándote así en este servidor, serás echado",
+  "desde moderación encontramos inapropiada esa actitud",
+  "¿te has leído las normas de este servidor? No lo tenemos claro",
+  "en este servidor no se tolera ese tipo de comportamiento",
+];
+
+export = class WarnCommand extends Commando.Command {
+  constructor(client: Makibot) {
+    super(client, {
+      name: "warn",
+      group: "moderation",
+      memberName: "warn",
+      description: "Permite aplicar warnings",
+      examples: ["warn @johndoe", "warn @johndoe spam"],
+      args: [
+        {
+          key: "target",
+          type: "user",
+          prompt: "Target a quien aplicar el warn",
+          default: "",
+        },
+        {
+          key: "reason",
+          type: "string",
+          prompt: "¿Alguna razón concreta?",
+          default: "",
+        },
+      ],
+    });
+  }
+
+  private isMod(user: GuildMember): boolean {
+    const modsRoleName = process.env.MODS_ROLE || "mods";
+    return user.roles.exists("name", modsRoleName);
+  }
+
+  run(msg: Commando.CommandMessage, args: WarnCommandArguments) {
+    if (!this.isMod(msg.member)) {
+      return Promise.resolve([]);
+    }
+
+    // Get the member behind this user.
+    const memberToWarn = msg.guild.member(args.target);
+
+    // Warn this user.
+    const warnRoleName = process.env.WARN_ROLE || "warn";
+    const warnRole = msg.guild.roles.find("name", warnRoleName);
+    memberToWarn.addRole(warnRole);
+
+    // Remove this user from the helpers role if they were.
+    const helperRoleName = process.env.HELPER_ROLE || "helpers";
+    const helperRole = msg.guild.roles.find("name", helperRoleName);
+    memberToWarn.removeRole(helperRole);
+
+    // Send a message to the public modlog.
+    const embed: RichEmbedOptions = {
+      title: `Se llamó la atención a ${memberToWarn.user.tag}`,
+      color: 16545847,
+      description: args.reason ? `**Razón**: ${args.reason}` : null,
+      author: {
+        name: memberToWarn.user.tag,
+        icon_url: memberToWarn.user.avatarURL,
+      },
+      footer: {
+        text: "Mensaje de moderación automático",
+      },
+    };
+
+    const modlogChannelName = process.env.PUBLIC_MODLOG_CHANNEL || "modlog";
+    const modlogChannel = msg.guild.channels.find("name", modlogChannelName);
+    if (modlogChannel.type === "text") {
+      const randomMessage = messages[Math.floor(Math.random() * messages.length)];
+      const message = `<@${memberToWarn.id}>: ${randomMessage}`;
+      (<TextChannel>modlogChannel).send(message, { embed });
+    }
+
+    return Promise.resolve([]);
+  }
+};

--- a/src/hooks/warn.ts
+++ b/src/hooks/warn.ts
@@ -10,7 +10,8 @@ function isMessageWarned(message: Message): boolean {
   if (!warnReaction) {
     return false;
   }
-  return !!warnReaction.users.find((user) => server.modsRole.members.exists("id", user.id));
+  const mods = server.modsRole.members;
+  return !!warnReaction.users.find((user) => mods.exists("id", user.id));
 }
 
 export default class WarnService implements Hook {
@@ -35,7 +36,10 @@ export default class WarnService implements Hook {
     const server = new Server(reaction.message.guild);
 
     const modRole = server.modsRole;
-    if (!modRole.members.exists("id", author.id) || modRole.members.exists("id", target.id)) {
+
+    const authorIsMod = modRole.members.exists("id", author.id);
+    const targetIsMod = modRole.members.exists("id", target.id);
+    if (!authorIsMod || targetIsMod) {
       return;
     }
 

--- a/src/hooks/warn.ts
+++ b/src/hooks/warn.ts
@@ -2,10 +2,12 @@ import Hook from "./hook";
 import Makibot from "../Makibot";
 import applyWarn from "../lib/warn";
 import { GuildMember, Message, MessageReaction, User } from "discord.js";
+import Server from "../lib/server";
 
 function isMod(user: GuildMember): boolean {
-  const modsRoleName = process.env.MODS_ROLE || "mods";
-  return user.roles.exists("name", modsRoleName);
+  const server = new Server(user.guild);
+  const modRole = server.modsRole;
+  return modRole.members.exists("id", user.id);
 }
 
 function isMessageWarned(message: Message): boolean {

--- a/src/hooks/warn.ts
+++ b/src/hooks/warn.ts
@@ -1,0 +1,51 @@
+import Hook from "./hook";
+import Makibot from "../Makibot";
+import applyWarn from "../lib/warn";
+import { GuildMember, Message, MessageReaction, User } from "discord.js";
+
+function isMod(user: GuildMember): boolean {
+  const modsRoleName = process.env.MODS_ROLE || "mods";
+  return user.roles.exists("name", modsRoleName);
+}
+
+function isMessageWarned(message: Message): boolean {
+  const warnReaction = message.reactions.find((reaction) => reaction.emoji.name === "⚠️");
+  if (!warnReaction) {
+    return false;
+  }
+  return !!warnReaction.users.find((user) => isMod(message.guild.member(user)));
+}
+
+export default class WarnService implements Hook {
+  private client: Makibot;
+
+  constructor(client: Makibot) {
+    this.client = client;
+
+    this.client.on("messageReactionAdd", (reaction, user) =>
+      this.messageReactionAdd(reaction, user)
+    );
+  }
+
+  private messageReactionAdd(reaction: MessageReaction, user: User) {
+    // I can only react to messages sent to guild text channels.
+    if (reaction.message.channel.type !== "text" || !reaction.message.guild) {
+      return;
+    }
+
+    const guildUser = reaction.message.guild.member(user);
+    if (!isMod(guildUser)) {
+      console.log("No es un mod");
+      return;
+    }
+
+    if (reaction.emoji.name === "⚠️") {
+      applyWarn(reaction.message.guild, {
+        user: reaction.message.author,
+        message: reaction.message,
+      });
+    } else if (reaction.emoji.name === "🗑️" && isMessageWarned(reaction.message)) {
+      reaction.message.delete();
+    }
+  }
+}

--- a/src/lib/modlog.ts
+++ b/src/lib/modlog.ts
@@ -1,4 +1,4 @@
-import { RichEmbedOptions, GuildMember, RichEmbed } from "discord.js";
+import { RichEmbedOptions, GuildMember, RichEmbed, Message } from "discord.js";
 
 interface EmbedField {
   name: string;
@@ -104,5 +104,48 @@ export class LeaveModlogEvent extends ModlogEvent {
         value: this.member.joinedAt.toUTCString(),
       },
     ];
+  }
+}
+
+export class WarnModlogEvent extends ModlogEvent {
+  constructor(private member: GuildMember, private reason: string, private message: Message) {
+    super();
+  }
+
+  title(): string {
+    return "Se ha aplicado un warn";
+  }
+
+  icon(): string {
+    return "https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/120/twitter/247/warning_26a0.png";
+  }
+
+  color(): number {
+    return 0x9b59b6;
+  }
+
+  fields(): EmbedField[] {
+    const fields: EmbedField[] = [];
+    fields.push({
+      name: "Usuario",
+      value: this.member.user.tag,
+    });
+    if (this.reason) {
+      fields.push({
+        name: "Razón",
+        value: this.reason,
+      });
+    }
+    if (this.message) {
+      fields.push({
+        name: "Mensaje",
+        value: this.message.cleanContent,
+      });
+      fields.push({
+        name: "Fecha del mensaje",
+        value: this.message.createdAt.toISOString(),
+      });
+    }
+    return fields;
   }
 }

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -43,9 +43,24 @@ export default class Server {
     return this.getRoleByName(helperRoleName);
   }
 
+  get modsRole(): Role {
+    const modsRoleName = process.env.MODS_ROLE || "mods";
+    return this.getRoleByName(modsRoleName);
+  }
+
   get verifiedRole(): Role {
     const verifiedRoleName = process.env.VERIFY_ROLE || "verified";
     return this.getRoleByName(verifiedRoleName);
+  }
+
+  get warnRole(): Role {
+    const warnRoleName = process.env.WARN_ROLE || "warn";
+    return this.getRoleByName(warnRoleName);
+  }
+
+  get publicModlogChannel(): TextChannel {
+    const modlogChannelName = process.env.PUBLIC_MODLOG_CHANNEL || "public-modlog";
+    return this.getTextChannelByName(modlogChannelName);
   }
 
   get modlogChannel(): TextChannel {

--- a/src/lib/warn.ts
+++ b/src/lib/warn.ts
@@ -1,5 +1,6 @@
-import { Guild, Message, RichEmbedOptions, TextChannel, User } from "discord.js";
+import { Guild, Message, RichEmbedOptions, User } from "discord.js";
 import Server from "./server";
+import { WarnModlogEvent } from "./modlog";
 
 /**
  * Information that describes why the warn is being issued. This information
@@ -24,7 +25,7 @@ const messages = [
   "en este servidor no se tolera ese tipo de comportamiento",
 ];
 
-export default function applyWarn(guild: Guild, { user, message, reason }: WarnPayload) {
+export default function applyWarn(guild: Guild, { user, message, reason }: WarnPayload): void {
   // Get the member behind this user.
   const memberToWarn = guild.member(user);
   const server = new Server(guild);
@@ -49,6 +50,7 @@ export default function applyWarn(guild: Guild, { user, message, reason }: WarnP
     description: reason ? `**Razón**: ${reason}` : null,
     author: {
       name: memberToWarn.user.tag,
+      // eslint-disable-next-line @typescript-eslint/camelcase
       icon_url: memberToWarn.user.avatarURL,
     },
     footer: {
@@ -61,5 +63,11 @@ export default function applyWarn(guild: Guild, { user, message, reason }: WarnP
     const randomMessage = messages[Math.floor(Math.random() * messages.length)];
     const warnMessage = `<@${memberToWarn.id}>: ${randomMessage}`;
     publicModlog.send(warnMessage, { embed });
+  }
+
+  const privateModlog = server.modlogChannel;
+  if (privateModlog) {
+    const warnEvent = new WarnModlogEvent(memberToWarn, reason, message);
+    privateModlog.send(warnEvent.toDiscordEmbed());
   }
 }

--- a/src/lib/warn.ts
+++ b/src/lib/warn.ts
@@ -1,0 +1,61 @@
+import { Guild, Message, RichEmbedOptions, TextChannel, User } from "discord.js";
+
+/**
+ * Information that describes why the warn is being issued. This information
+ * may be logged into the private modlog for other mods to consume, and some
+ * public information may be sent to the public modlog channel.
+ */
+export interface WarnPayload {
+  /** The user that will receive the warn. */
+  user: User;
+
+  /** Optionally, the message that caused the warn to be applied. */
+  message?: Message;
+
+  /** The reason on why the warn was issued. */
+  reason?: string;
+}
+
+const messages = [
+  "si sigues comportándote así en este servidor, serás echado",
+  "desde moderación encontramos inapropiada esa actitud",
+  "¿te has leído las normas de este servidor? No lo tenemos claro",
+  "en este servidor no se tolera ese tipo de comportamiento",
+];
+
+export default function applyWarn(guild: Guild, { user, message, reason }: WarnPayload) {
+  // Get the member behind this user.
+  const memberToWarn = guild.member(user);
+
+  // Warn this user.
+  const warnRoleName = process.env.WARN_ROLE || "warn";
+  const warnRole = guild.roles.find("name", warnRoleName);
+  memberToWarn.addRole(warnRole);
+
+  // Remove this user from the helpers role if they were.
+  const helperRoleName = process.env.HELPER_ROLE || "helpers";
+  const helperRole = guild.roles.find("name", helperRoleName);
+  memberToWarn.removeRole(helperRole);
+
+  // Send a message to the public modlog.
+  const embed: RichEmbedOptions = {
+    title: `Se llamó la atención a ${memberToWarn.user.tag}`,
+    color: 16545847,
+    description: reason ? `**Razón**: ${reason}` : null,
+    author: {
+      name: memberToWarn.user.tag,
+      icon_url: memberToWarn.user.avatarURL,
+    },
+    footer: {
+      text: "Mensaje de moderación automático",
+    },
+  };
+
+  const modlogChannelName = process.env.PUBLIC_MODLOG_CHANNEL || "modlog";
+  const modlogChannel = guild.channels.find("name", modlogChannelName);
+  if (modlogChannel.type === "text") {
+    const randomMessage = messages[Math.floor(Math.random() * messages.length)];
+    const message = `<@${memberToWarn.id}>: ${randomMessage}`;
+    (<TextChannel>modlogChannel).send(message, { embed });
+  }
+}


### PR DESCRIPTION
This PR provides functionality to let moderators warn users that have been caught breaking rules in the server, rather than having to manually notify these users and maybe deleting messages.

Let's describe the following things:

* Warn: it is usually some kind of notice sent to users who break rules to tell them that unless they stop acting like that, they will probably get kicked or banned off from the server.
* Moderator: one of the allowed things for moderators to do is to issue warns to these users.
* Public modlog: it is a public channel where usually notices are sent, so that they can be read by users. At the moment in the makigas server, this is #moderacion.
* Private modlog: it is a private channel where the bot should log the actions that happen in the server with a more verbose level, but it can only be read by moderators. At the moment in the makigas server, it is #modlog.
* Mod chat-ops: it is a private channel that can only be used by moderators and that it is mainly used to coordinate moderation efforts. At the moment in the makigas server, it is #deathnote.
* Warn role: it is a role given to users who have received a warning. It paints their nickname with a different color, and it applies some additional restrictions other users may not have, such as not being able to send links.

Then, this PR will provide two ways to provide automatic warn to users.

## `!warn` command

This command can be issued by a moderator to trigger a warning into a specific user, optionally providing a reason on why a notice is given. Syntax:

* `!warn @user`: issue an automatic warn to the given user handle.
* `!warn @<handle>`: issue an automatic warn to the user whose user ID matches the one given.
* `!warn @user "reason"`: issue an automatic warn to the given user handle, with an additional parameter stating why a warn was given.

If the command is sent by a moderator, it will do the following:

* Add the mentioned user into the warn role.
* Remove the mentioned user from some roles, such as helpers.
* Send a notice to the public modlog mentioning the user to let the user know that they have received a warn. If a reason was given, also displays the reason here.
* Send a notice to the private modlog logging the same message.

Additional QA validation rules:

* The command should not do anything if the issuer is not a moderator.
* The bot should not crash if the mentioned user has left the server.
* At the moment, the command should not do anything if the warned user is already warned.
* The bot should not crash if the user is not part of any role.

## Warn reaction

If a moderator reacts to a message using the ⚠️ emoji, the bot should pick the message that was reacted, and the author who wrote that message, and initiate a warn request to the author of the message.

A confirmation prompt should be sent by the bot to the mod chat-ops channel asking for confirmation and maybe a reason. The following message is presented:

> `@[mod]`, vas a aplicar un warn a `@[target]`. Confirma que quieres hacer esto. Si quieres proporcionar una razón para aplicar un warn, responde a este mensaje –eso servirá de confirmación.

The bot should react to its own message using both the ✅ and the ❌ emojis, to make it easier to answer for the mod.
* If the moderator reacts to this message with a ✅ emoji, it should issue a warn to the user to be warned.
* If the moderator reacts to this message with a ❌ emoji, it should disregard the warn request, send a message saying "Acción cancelada" and stop.
* If the moderator sends a message in the following 60 seconds, the contents of that message will be added as a reason to warn the user.
* If the moderator does not react nor send a message in the following 60 seconds, the request is automatically cancelled: send a message saying "Acción cancelada por inanición" and stop.

If the warn request is confirmed, it will do the following:

* Add the mentioned user into the warn role.
* Remove the mentioned user from some roles, such as helpers.
* Send a notice to the public modlog mentioning the user to let the user know that they have received a warn. If a reason was given, also displays the reason here.
* Send a notice to the private modlog logging the same message. The infringing message that the moderator sent the ⚠️ to, will be quoted in the private modlog.

Additional QA validation rules:

* Nothing should happen if a user that is not a mod reacts to a message with ⚠️.
* The bot should not crash if the user has already left the server.
* If the message is deleted while a mod is still, it should still proceed and log the deleted message into the private modlog.

## Delete reaction

If a message that was marked with ⚠️ by a moderator, whose user has been already warned, receives a second reaction using the 🗑️ emoji, the bot should automatically delete the message without further action.

Additional QA validation rules:

* Nothing should happen if a user that is not a mod reacts to a message that already has a ⚠️.
* Nothing should happen if a mod reacts with 🗑️  to a message that has a ⚠️ issued by someone who is not a moderator.
* The bot should not crash if the message is deleted by the time the bot processes the request.
* The message should not be deleted if a mod reacts with 🗑️ to a message that has no warnings.
* The message should not be deleted if a moderator uses the warn emoji and issues a warn notice after a message receives the 🗑️  emoji with no warning beforehand.