### PR TITLE
refactor: use fancier modlog messages

### DIFF
--- a/src/hooks/roster.ts
+++ b/src/hooks/roster.ts
@@ -2,6 +2,7 @@ import { Guild, GuildMember, TextChannel } from "discord.js";
 
 import Hook from "./hook";
 import Makibot from "../Makibot";
+import { JoinModlogEvent, LeaveModlogEvent } from "../lib/modlog";
 
 /**
  * The roster service plugs hooks whenever an user leaves the guild.
@@ -10,8 +11,8 @@ import Makibot from "../Makibot";
  */
 export default class RosterService implements Hook {
   constructor(client: Makibot) {
-    client.on("guildMemberAdd", member => this.memberJoin(member));
-    client.on("guildMemberRemove", member => this.memberLeft(member));
+    client.on("guildMemberAdd", (member) => this.memberJoin(member));
+    client.on("guildMemberRemove", (member) => this.memberLeft(member));
   }
 
   /**
@@ -22,9 +23,8 @@ export default class RosterService implements Hook {
     let modlog = this.getModlog(member.guild);
     if (modlog) {
       modlog
-        .send(`:high_brightness: ${member.user.tag} se unió al servidor.`)
-        .then(msg => console.log(`Enviando mensaje: ${msg}.`))
-        .catch(e => console.error(`Error: ${e}`));
+        .send(new JoinModlogEvent(member).toDiscordEmbed())
+        .catch((e) => console.error(`Error: ${e}`));
     }
   }
 
@@ -36,9 +36,8 @@ export default class RosterService implements Hook {
     let modlog = this.getModlog(member.guild);
     if (modlog) {
       modlog
-        .send(`:x: ${member.user.tag} abandonó el servidor.`)
-        .then(msg => console.log(`Enviado mensaje: ${msg}.`))
-        .catch(e => console.error(`Error: ${e}`));
+        .send(new LeaveModlogEvent(member).toDiscordEmbed())
+        .catch((e) => console.error(`Error: ${e}`));
     }
   }
 

--- a/src/lib/modlog.ts
+++ b/src/lib/modlog.ts
@@ -1,0 +1,108 @@
+import { RichEmbedOptions, GuildMember, RichEmbed } from "discord.js";
+
+interface EmbedField {
+  name: string;
+  value: string;
+  inline?: boolean;
+}
+
+abstract class ModlogEvent {
+  public toDiscordEmbed(): RichEmbed {
+    const options: RichEmbedOptions = {
+      color: this.color(),
+      footer: {
+        icon_url:
+          "https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/120/twitter/247/page-with-curl_1f4c3.png",
+        text: "Mensaje de moderación automática",
+      },
+      author: {
+        name: this.title(),
+        icon_url: this.icon(),
+      },
+      fields: this.fields(),
+    };
+    return new RichEmbed(options);
+  }
+
+  abstract title(): string;
+
+  abstract icon(): string;
+
+  abstract color(): number;
+
+  abstract fields(): EmbedField[];
+}
+
+export class JoinModlogEvent extends ModlogEvent {
+  constructor(private member: GuildMember) {
+    super();
+  }
+
+  title(): string {
+    return "Nuevo miembro del servidor";
+  }
+
+  icon(): string {
+    return "https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/120/twitter/247/bright-button_1f506.png";
+  }
+
+  color(): number {
+    return 0xfeaf40;
+  }
+
+  fields(): EmbedField[] {
+    return [
+      {
+        name: "Handle",
+        value: this.member.user.tag,
+      },
+      {
+        name: "ID",
+        value: this.member.user.id,
+      },
+      {
+        name: "Se unió a Discord",
+        value: this.member.user.createdAt.toUTCString(),
+      },
+    ];
+  }
+}
+
+export class LeaveModlogEvent extends ModlogEvent {
+  constructor(private member: GuildMember) {
+    super();
+  }
+
+  title(): string {
+    return "Abandono del servidor";
+  }
+
+  icon(): string {
+    return "https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/120/twitter/247/cross-mark_274c.png";
+  }
+
+  color(): number {
+    return 0xdd3247;
+  }
+
+  fields(): EmbedField[] {
+    return [
+      {
+        name: "Handle",
+        value: this.member.user.tag,
+      },
+      {
+        name: "ID",
+        value: this.member.user.id,
+      },
+      {
+        name: "Se unió a Discord",
+        value: this.member.user.createdAt.toUTCString(),
+      },
+      {
+        name: "Se unió al servidor",
+        value: this.member.joinedAt.toUTCString(),
+      },
+    ];
+  }
+}


### PR DESCRIPTION
This commit will refactor the messages sent by the roster service, so
that they use a Rich Embed rather than a simple string. The code has
been refactored into a structure called ModlogEvent, so that it can be
extended by further actions that would require an event to be sent to
the modlog.