### PR TITLE
refactor: wrap role and channel accessors in Server class

### DIFF
--- a/src/Makibot.ts
+++ b/src/Makibot.ts
@@ -40,12 +40,9 @@ export default class Makibot extends Commando.CommandoClient {
           });
 
           // Register hooks.
-          var pin = new PinService(this);
-          var roster = new RosterService(this);
-
-          if (process.env.VERIFY_CHANNEL && process.env.VERIFY_ROLE) {
-            var verify = new VerifyService(this);
-          }
+          new PinService(this);
+          new RosterService(this);
+          new VerifyService(this);
         })
         .catch(console.log);
     });

--- a/src/hooks/pin.ts
+++ b/src/hooks/pin.ts
@@ -2,6 +2,7 @@ import Discord from "discord.js";
 
 import Hook from "./hook";
 import Makibot from "../Makibot";
+import Server from "../lib/server";
 
 export default class PinService implements Hook {
   private client: Makibot;
@@ -10,16 +11,16 @@ export default class PinService implements Hook {
     this.client = client;
 
     this.client.on("messageReactionAdd", (reaction, user) =>
-      this.messageReactionAdd(reaction, user),
+      this.messageReactionAdd(reaction, user)
     );
     this.client.on("messageReactionRemove", (reaction, user) =>
-      this.messageReactionRemove(reaction, user),
+      this.messageReactionRemove(reaction, user)
     );
-    this.client.on("messageReactionRemoveAll", message => this.messageReactionRemoveAll(message));
+    this.client.on("messageReactionRemoveAll", (message) => this.messageReactionRemoveAll(message));
 
-    this.client.guilds.forEach(guild => {
+    this.client.guilds.forEach((guild) => {
       // Cache recent messages per server.
-      guild.channels.forEach(channel => {
+      guild.channels.forEach((channel) => {
         if (channel.type == "text") {
           (<Discord.TextChannel>channel).fetchMessages({ limit: 100 }).catch(console.error);
         }
@@ -47,8 +48,8 @@ export default class PinService implements Hook {
     }
 
     // Get the pinboard channel.
-    let pinboard = this.getPinboardChannel(message.guild);
-    let pinchannel = <Discord.TextChannel>message.guild.channels.get(pinboard);
+    const server = new Server(message.guild);
+    const pinchannel = server.pinboardChannel;
     let srcchannel = <Discord.TextChannel>message.channel;
 
     if (pinchannel == null) {
@@ -92,7 +93,7 @@ export default class PinService implements Hook {
    * @return an URL to an embed or null if no embed has thumbnails.
    */
   private getEmbedThumbnail(message: Discord.Message): string {
-    let withThumbnails = message.embeds.filter(e => e.thumbnail);
+    let withThumbnails = message.embeds.filter((e) => e.thumbnail);
     if (withThumbnails.length > 0) {
       return withThumbnails[0].url;
     } else {
@@ -105,7 +106,7 @@ export default class PinService implements Hook {
    * @return an URL to an image attached to the message or null if no images.
    */
   private getAttachedImage(message: Discord.Message): string {
-    let attachedImages = message.attachments.filter(a => a.width != null && a.height != null);
+    let attachedImages = message.attachments.filter((a) => a.width != null && a.height != null);
     if (attachedImages.size > 0) {
       return attachedImages.first().url;
     } else {
@@ -127,7 +128,7 @@ export default class PinService implements Hook {
 
   private messageReactionRemove(reaction: Discord.MessageReaction, user: Discord.User) {
     console.log(
-      `${user.tag} unreacted to ${reaction.message.id} with emoji ${reaction.emoji.name}`,
+      `${user.tag} unreacted to ${reaction.message.id} with emoji ${reaction.emoji.name}`
     );
   }
 
@@ -141,13 +142,5 @@ export default class PinService implements Hook {
    */
   private getTriggerEmoji(server: Discord.Guild): string {
     return this.client.provider.get(server, "Pin.Emoji", "\u2b50");
-  }
-
-  /**
-   * Recupera el canal al que enviar el mensaje.
-   * @return Snowflake
-   */
-  private getPinboardChannel(server: Discord.Guild): string {
-    return this.client.provider.get(server, "Pin.Pinboard", null);
   }
 }

--- a/src/hooks/roster.ts
+++ b/src/hooks/roster.ts
@@ -1,8 +1,9 @@
-import { Guild, GuildMember, TextChannel } from "discord.js";
+import { GuildMember } from "discord.js";
 
 import Hook from "./hook";
 import Makibot from "../Makibot";
 import { JoinModlogEvent, LeaveModlogEvent } from "../lib/modlog";
+import Server from "../lib/server";
 
 /**
  * The roster service plugs hooks whenever an user leaves the guild.
@@ -19,8 +20,9 @@ export default class RosterService implements Hook {
    * This event is triggered whenever an user joins the guild server.
    * @param member the member that has joined the server.
    */
-  private memberJoin(member: GuildMember) {
-    let modlog = this.getModlog(member.guild);
+  private memberJoin(member: GuildMember): void {
+    const server = new Server(member.guild);
+    const modlog = server.modlogChannel;
     if (modlog) {
       modlog
         .send(new JoinModlogEvent(member).toDiscordEmbed())
@@ -32,31 +34,13 @@ export default class RosterService implements Hook {
    * This event is triggered whenever an user leaves the guild server.
    * @param member the member that has left the server.
    */
-  private memberLeft(member: GuildMember) {
-    let modlog = this.getModlog(member.guild);
+  private memberLeft(member: GuildMember): void {
+    const server = new Server(member.guild);
+    const modlog = server.modlogChannel;
     if (modlog) {
       modlog
         .send(new LeaveModlogEvent(member).toDiscordEmbed())
         .catch((e) => console.error(`Error: ${e}`));
-    }
-  }
-
-  /**
-   * Resolve and get the channel to use as modlog channel in this guild.
-   * @param guild the guild to get the modlog channel from.
-   */
-  private getModlog(guild: Guild): TextChannel | null {
-    /* If a modlog ID is not registered, there is no modlog. */
-    if (!process.env.MODLOG) {
-      return null;
-    }
-
-    /* Find a guild channel with such ID. */
-    if (guild.channels.exists("id", process.env.MODLOG)) {
-      let channel = guild.channels.find("id", process.env.MODLOG);
-      return channel.type == "text" ? <TextChannel>channel : null;
-    } else {
-      return null;
     }
   }
 }

--- a/src/hooks/verify.ts
+++ b/src/hooks/verify.ts
@@ -1,7 +1,8 @@
-import { Message, TextChannel, Guild, Role } from "discord.js";
+import { Message } from "discord.js";
 
 import Hook from "./hook";
 import Makibot from "../Makibot";
+import Server from "../lib/server";
 
 /**
  * The verify service allows a server to force users to validate themselves by
@@ -16,63 +17,43 @@ export default class VerifyService implements Hook {
     "un kick o un ban.",
   ].join(" ");
 
-  private channel: string;
-
   private token: string;
 
-  private role: string;
-
   constructor(client: Makibot) {
-    this.channel = process.env.VERIFY_CHANNEL;
-    this.role = process.env.VERIFY_ROLE;
     this.token = process.env.VERIFY_TOKEN;
-    client.on("message", message => this.handleMessage(message));
+    client.on("message", (message) => this.handleMessage(message));
   }
 
-  private handleMessage(message: Message) {
+  private handleMessage(message: Message): void {
     if (!this.isVerificationMessage(message)) {
       /* Not a message to validate the account. Bail out. */
       return;
     }
 
-    let channel = this.getVerificationChannel(message.guild);
+    const server = new Server(message.guild);
+    const channel = server.captchasChannel;
+    if (!channel) {
+      throw new ReferenceError(`Captchas text channel not found in guild ${message.guild.name}!`);
+    }
     if (message.channel.id != channel.id) {
       /* Not a message sent to the verification channel. Bail out. */
       return;
     }
 
-    let role = this.getVerificationRole(message.guild);
+    const role = server.verifiedRole;
+    if (!role) {
+      throw new ReferenceError(`Verification role not found in guild ${message.guild.name}!`);
+    }
     message.member
       .addRole(role)
-      .then(member => member.send(VerifyService.ACCEPTED))
-      .catch(e => console.error(e));
-  }
-
-  /** Returns the associated role to verified accounts on this guild. */
-  private getVerificationRole(guild: Guild): Role {
-    let role = guild.roles.find("name", this.role);
-    if (!role) {
-      throw new ReferenceError(`Role ${this.role} not found in guild ${guild.name}!`);
-    }
-    return role;
-  }
-
-  /** Returns the associated channel to verify accounts on this guild. */
-  private getVerificationChannel(guild: Guild): TextChannel {
-    let channel = guild.channels.find("name", this.channel);
-    if (!channel) {
-      throw new ReferenceError(`Channel ${this.channel} not found in guild ${guild.name}!`);
-    }
-    if (channel.type != "text") {
-      throw new ReferenceError(`Channel ${this.channel} is not a text channel!`);
-    }
-    return <TextChannel>channel;
+      .then((member) => member.send(VerifyService.ACCEPTED))
+      .catch((e) => console.error(e));
   }
 
   /** Returns true if the given message is a validation message. */
-  private isVerificationMessage(message: Message) {
-    let cleanToken = this.token.toLowerCase().trim();
-    let inputToken = message.content.toLowerCase().trim();
+  private isVerificationMessage(message: Message): boolean {
+    const cleanToken = this.token.toLowerCase().trim();
+    const inputToken = message.content.toLowerCase().trim();
     return cleanToken === inputToken;
   }
 }

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -1,0 +1,65 @@
+import { Guild, Role, TextChannel } from "discord.js";
+import Makibot from "../Makibot";
+
+export default class Server {
+  constructor(private guild: Guild) {}
+
+  private getRoleByName(name: string): Role {
+    if (name && this.guild.roles.exists("name", name)) {
+      return this.guild.roles.find("name", name);
+    }
+    return null;
+  }
+
+  private getRoleByID(id: string): Role {
+    if (id && this.guild.roles.exists("id", id)) {
+      return this.guild.roles.find("id", id);
+    }
+    return null;
+  }
+
+  private getTextChannelByName(name: string): TextChannel {
+    if (name && this.guild.channels.exists("name", name)) {
+      const channel = this.guild.channels.find("name", name);
+      if (channel.type === "text") {
+        return channel as TextChannel;
+      }
+    }
+    return null;
+  }
+
+  private getTextChannelByID(id: string): TextChannel {
+    if (id && this.guild.channels.exists("id", id)) {
+      const channel = this.guild.channels.find("id", id);
+      if (channel.type === "text") {
+        return channel as TextChannel;
+      }
+    }
+    return null;
+  }
+
+  get helperRole(): Role {
+    const helperRoleName = process.env.HELPER_ROLE || "helpers";
+    return this.getRoleByName(helperRoleName);
+  }
+
+  get verifiedRole(): Role {
+    const verifiedRoleName = process.env.VERIFY_ROLE || "verified";
+    return this.getRoleByName(verifiedRoleName);
+  }
+
+  get modlogChannel(): TextChannel {
+    return this.getTextChannelByID(process.env.MODLOG);
+  }
+
+  get captchasChannel(): TextChannel {
+    const captchasChannelName = process.env.VERIFY_CHANNEL || "captchas";
+    return this.getTextChannelByName(captchasChannelName);
+  }
+
+  get pinboardChannel(): TextChannel {
+    const client = this.guild.client as Makibot;
+    const pinboardChannelName = client.provider.get(this.guild, "Pin.Pinboard", null);
+    return this.getTextChannelByName(pinboardChannelName);
+  }
+}


### PR DESCRIPTION
This commit will refactor all the accessors to channels and roles, that
are currently scattered around the source code of the bot using stuff
like guild.channels.get, guild.channels.find and guild.channels.exists,
into a single class that adapts a discord.js Guild, with methods that
retrieve each role or channel of interest on its own.