### PR TITLE
fix: shutdown when the disconnect event is received

### DIFF
--- a/src/Makibot.ts
+++ b/src/Makibot.ts
@@ -44,14 +44,19 @@ export default class Makibot extends Commando.CommandoClient {
         .catch(console.log);
     });
 
+    this.on("disconnect", (error) => {
+      console.error(`The bot has been disconnected.`);
+      this.shutdown(1);
+    });
+
     this.login(ConfigSchema.token);
   }
 
-  shutdown() {
+  shutdown(exitCode = 0) {
     console.log("The bot was asked to shutdown.");
     this.destroy().finally(() => {
       console.log("Good night!");
-      process.exit(0);
+      process.exit(exitCode);
     });
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,5 +3,5 @@
 import Makibot from "./Makibot";
 
 let makibot = new Makibot();
-process.on("SIGTERM", () => makibot.shutdown());
-process.on("SIGINT", () => makibot.shutdown());
+process.on("SIGTERM", () => makibot.shutdown(0));
+process.on("SIGINT", () => makibot.shutdown(0));


### PR DESCRIPTION
This commit will address an issue where the bot would silently
disconnect from the server, but not handle the error and never
reconnect, causing the bot to appear online, but not send any messages
or react to any external event anymore.