### PR TITLE
fix: channels are not being found

### DIFF
--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -20,7 +20,7 @@ export default class Server {
   }
 
   private getTextChannelByName(name: string): TextChannel {
-    if (!name) {
+    if (name) {
       const channel = this.guild.channels.find((channel) => channel.name === name);
       if (channel && channel.type === "text") {
         return channel as TextChannel;
@@ -31,7 +31,7 @@ export default class Server {
   }
 
   private getTextChannelByID(id: string): TextChannel {
-    if (!id) {
+    if (id) {
       const channel = this.guild.channels.find((channel) => channel.id === id);
       if (channel && channel.type === "text") {
         return channel as TextChannel;


### PR DESCRIPTION
This commit fixes a regression recently introduced while migrating to
Discord 11.4, where the text channels retrieved by the helper methods
added to server.ts couldn't be found.

I need to be more careful while I type code.
