### PR TITLE
feat: include channel in the WarnModlogMessage

### DIFF
--- a/src/lib/modlog.ts
+++ b/src/lib/modlog.ts
@@ -1,4 +1,4 @@
-import { RichEmbedOptions, GuildMember, RichEmbed, Message } from "discord.js";
+import { RichEmbedOptions, GuildMember, RichEmbed, Message, TextChannel } from "discord.js";
 
 interface EmbedField {
   name: string;
@@ -141,6 +141,13 @@ export class WarnModlogEvent extends ModlogEvent {
         name: "Mensaje",
         value: this.message.cleanContent,
       });
+      if (this.message.channel.type == "text") {
+        const textChannel = this.message.channel as TextChannel;
+        fields.push({
+          name: "Canal",
+          value: `#${textChannel.name}`,
+        });
+      }
       fields.push({
         name: "Fecha del mensaje",
         value: this.message.createdAt.toISOString(),


### PR DESCRIPTION
This commit will make the message sent to the private modlog channel
include the channel at which the original message that was warned and
maybe deleted was initially sent.