### PR TITLE
feat: disallow !helper to users who have been warned

### DIFF
--- a/src/commands/utiles/helper.ts
+++ b/src/commands/utiles/helper.ts
@@ -34,6 +34,10 @@ export = class HelperCommand extends Commando.Command {
       return msg.channel.send("Oh, oh. Parece que este bot no está bien configurado.");
     }
 
+    if (msg.member.roles.has(server.warnRole.id)) {
+      return msg.reply("Tienes anulado el comando !helpers debido a una infracción.");
+    }
+
     // Act on behalf of what the user wants.
     switch (HelperCommand.opmode(args.mode)) {
       case "yes":


### PR DESCRIPTION
After applying this commit, users who receive a warn and have the warn
role cannot use the !helper command to change their helper presence
status. Because !warn will now revoke the helper role automatically, the
consequence is that, if an user is warned either through use of !warn or
through use of the :warn: emoji, those users won't be able to become
helpers until the warn is revoked.
