### PR TITLE
feat(mod): send successful verifications to modlog

### DIFF
--- a/src/hooks/verify.ts
+++ b/src/hooks/verify.ts
@@ -3,6 +3,7 @@ import { GuildMember, Message } from "discord.js";
 import Hook from "./hook";
 import Makibot from "../Makibot";
 import Server from "../lib/server";
+import { VerifyModlogEvent } from "../lib/modlog";
 
 const TOO_SOON =
   "%s, te he entendido, pero tienes que esperar un par de minutos para poder ser aprobado.";
@@ -65,6 +66,13 @@ export default class VerifyService implements Hook {
       .addRole(role)
       .then((member) => member.send(VerifyService.ACCEPTED))
       .catch((e) => console.error(e));
+
+    /* Log the verify attempt. */
+    if (server.modlogChannel) {
+      server.modlogChannel
+        .send(new VerifyModlogEvent(message.member).toDiscordEmbed())
+        .catch((e) => console.error(`Error: ${e}`));
+    }
   }
 
   /** Returns true if the given message is a validation message. */

--- a/src/lib/modlog.ts
+++ b/src/lib/modlog.ts
@@ -70,6 +70,41 @@ export class JoinModlogEvent extends ModlogEvent {
   }
 }
 
+export class VerifyModlogEvent extends ModlogEvent {
+  constructor(private member: GuildMember) {
+    super();
+  }
+
+  title(): string {
+    return "Miembro ha sido verificado";
+  }
+
+  icon(): string {
+    return "https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/120/twitter/248/check-box-with-check_2611.png";
+  }
+
+  color(): number {
+    return 0x5a7702;
+  }
+
+  fields(): EmbedField[] {
+    return [
+      {
+        name: "Handle",
+        value: this.member.user.tag,
+      },
+      {
+        name: "ID",
+        value: this.member.user.id,
+      },
+      {
+        name: "Se unió a Discord",
+        value: this.member.user.createdAt.toUTCString(),
+      },
+    ];
+  }
+}
+
 export class LeaveModlogEvent extends ModlogEvent {
   constructor(private member: GuildMember) {
     super();


### PR DESCRIPTION
This commit will make the bot send a message to the private modlog
channel whenever an user verifies the account successfully. This is done
to make moderation easier in case the bot goes down, because it is easy
to see which users have been accepted.
