### PR TITLE
feat: add antiraid mode

### DIFF
--- a/src/Makibot.ts
+++ b/src/Makibot.ts
@@ -8,8 +8,11 @@ import PinService from "./hooks/pin";
 import RosterService from "./hooks/roster";
 import VerifyService from "./hooks/verify";
 import WarnService from "./hooks/warn";
+import AntiRaid from "./lib/antiraid";
 
 export default class Makibot extends Commando.CommandoClient {
+  readonly antiraid: AntiRaid;
+
   public constructor() {
     super({
       commandPrefix: "!",
@@ -17,6 +20,8 @@ export default class Makibot extends Commando.CommandoClient {
       disableEveryone: true,
       unknownCommandResponse: false,
     });
+
+    this.antiraid = new AntiRaid(this);
 
     this.registry.registerDefaultTypes();
     this.registry.registerGroups([
@@ -40,6 +45,9 @@ export default class Makibot extends Commando.CommandoClient {
           new RosterService(this);
           new VerifyService(this);
           new WarnService(this);
+
+          // Init the antiraid engine.
+          this.antiraid.init();
         })
         .catch(console.log);
     });

--- a/src/clankctl.ts
+++ b/src/clankctl.ts
@@ -58,6 +58,36 @@ clankctl.command(
 );
 
 clankctl.command(
+  "antiraid [mode]",
+  "enable or disable the antiraid mode",
+  () => ({}),
+  async (argv: { mode?: string }) => {
+    if (argv.mode) {
+      switch (argv.mode) {
+        case "on":
+          await client.setRaidMode(true);
+          console.log("Antiraid mode has been enabled");
+          process.exit(0);
+          break;
+        case "off":
+          await client.setRaidMode(false);
+          console.log("Antiraid mode has been disabled");
+          process.exit(0);
+          break;
+        default:
+          console.error("Keyword not understood: " + argv.mode);
+          process.exit(1);
+          break;
+      }
+    } else {
+      const status = await client.raidModeStatus();
+      console.log(`Antiraid mode ${status ? "is enabled" : "is disabled"}`);
+      process.exit(0);
+    }
+  }
+);
+
+clankctl.command(
   "set-config <guild> <key> <value>",
   "update the configuration for a specific guild",
   () => ({}),

--- a/src/commands/moderation/raid.ts
+++ b/src/commands/moderation/raid.ts
@@ -1,0 +1,54 @@
+import { Message } from "discord.js";
+import { Command, CommandMessage } from "discord.js-commando";
+import AntiRaid from "../../lib/antiraid";
+import Member from "../../lib/member";
+import Makibot from "../../Makibot";
+
+interface RaidCommandArguments {
+  command?: string;
+}
+
+export = class RaidCommand extends Command {
+  private antiraid: AntiRaid;
+
+  constructor(client: Makibot) {
+    super(client, {
+      name: "raid",
+      memberName: "raid",
+      group: "moderation",
+      description: "Activa o desactiva la protección de raids",
+      args: [
+        {
+          key: "command",
+          type: "string",
+          prompt: "¿Operación?",
+          default: "status",
+        },
+      ],
+    });
+    this.antiraid = client.antiraid;
+  }
+
+  async run(msg: CommandMessage, { command }: RaidCommandArguments): Promise<Message> {
+    // Must be mod to run this command.
+    const author = new Member(msg.member);
+    if (author.moderator) {
+      const operation = command.toLowerCase().trim();
+      if (operation == "on") {
+        await this.antiraid.setRaidMode(true);
+        return msg.channel.send("Modo antiraid ha sido habilitado");
+      } else if (operation == "off") {
+        await this.antiraid.setRaidMode(false);
+        return msg.channel.send("Modo antiraid ha sido desactivado");
+      } else if (operation == "status") {
+        if (this.antiraid.raidMode) {
+          return msg.channel.send("El modo antiraid está activo");
+        } else {
+          return msg.channel.send("El modo antiraid está inactivo");
+        }
+      } else {
+        return msg.channel.send("Uso: raid [on|off|status]");
+      }
+    }
+  }
+};

--- a/src/lib/antiraid.ts
+++ b/src/lib/antiraid.ts
@@ -1,0 +1,24 @@
+import Makibot from "../Makibot";
+
+export default class AntiRaid {
+  constructor(private client: Makibot) {}
+
+  async init(): Promise<void> {
+    await this.syncPresence();
+  }
+
+  get raidMode(): boolean {
+    return this.client.provider.get("global", "raidmode", false);
+  }
+
+  async setRaidMode(enabled: boolean): Promise<void> {
+    await this.client.provider.set("global", "raidmode", enabled);
+    await this.syncPresence();
+  }
+
+  private async syncPresence(): Promise<void> {
+    await this.client.user.setPresence({
+      status: this.raidMode ? "dnd" : "online",
+    });
+  }
+}

--- a/src/lib/http/client.ts
+++ b/src/lib/http/client.ts
@@ -27,6 +27,28 @@ export default class Client {
     }
   }
 
+  async raidModeStatus(): Promise<boolean> {
+    const response = await this.client.get("/antiraid");
+    if (response.status !== 200) {
+      throw new Error(`${response.statusText}: ${response.data}`);
+    }
+    return response.data.antiraid as boolean;
+  }
+
+  async setRaidMode(mode: boolean): Promise<void> {
+    if (mode) {
+      const response = await this.client.post("/antiraid");
+      if (response.status !== 200) {
+        throw new Error(`${response.statusText}: ${response.data}`);
+      }
+    } else {
+      const response = await this.client.delete("/antiraid");
+      if (response.status !== 200) {
+        throw new Error(`${response.statusText}: ${response.data}`);
+      }
+    }
+  }
+
   async guilds(): Promise<Partial<ServerJSONSchema>[]> {
     const response = await this.client.get("/guilds");
     return response.data as Partial<ServerJSONSchema>[];

--- a/src/lib/http/server.ts
+++ b/src/lib/http/server.ts
@@ -28,6 +28,43 @@ export default function serverFactory(makibot: Makibot): express.Express {
     }
   });
 
+  app.get("/antiraid", (req, res) => {
+    res.contentType("application/json");
+    res.status(200).json({ antiraid: makibot.antiraid.raidMode });
+  });
+
+  app.post("/antiraid", (req, res) => {
+    makibot.antiraid
+      .setRaidMode(true)
+      .then(() => {
+        res.contentType("application/json");
+        res.status(200).json({
+          accepted: true,
+          newMode: makibot.antiraid.raidMode,
+        });
+      })
+      .catch((e) => {
+        res.contentType("text/plain");
+        res.status(500).send(`Command could not be handled: ${e}`);
+      });
+  });
+
+  app.delete("/antiraid", (req, res) => {
+    makibot.antiraid
+      .setRaidMode(false)
+      .then(() => {
+        res.contentType("application/json");
+        res.status(200).json({
+          accepted: true,
+          newMode: makibot.antiraid.raidMode,
+        });
+      })
+      .catch((e) => {
+        res.contentType("text/plain");
+        res.status(500).send(`Command could not be handled: ${e}`);
+      });
+  });
+
   app.get("/guilds", (req, res) => {
     res.json(
       makibot.guilds.map((guild) => ({

--- a/src/lib/member.ts
+++ b/src/lib/member.ts
@@ -15,6 +15,10 @@ export default class Member {
     return this.guildMember.roles.has(this.server.verifiedRole?.id);
   }
 
+  get moderator(): boolean {
+    return this.guildMember.roles.has(this.server.modsRole?.id);
+  }
+
   get cooldown(): boolean {
     if (!this.guildMember.joinedAt) {
       /* TODO: Investigate why THIS happens. */
@@ -31,6 +35,15 @@ export default class Member {
       await this.guildMember.addRole(this.server.verifiedRole);
     } else {
       await this.guildMember.removeRole(this.server.verifiedRole);
+    }
+    return value;
+  }
+
+  async setModerator(value: boolean): Promise<boolean> {
+    if (value) {
+      await this.guildMember.addRole(this.server.modsRole);
+    } else {
+      await this.guildMember.removeRole(this.server.modsRole);
     }
     return value;
   }


### PR DESCRIPTION
This commit adds a toggle called AntiRaid to the Discord client. When
this toggle is enabled, the bot enters stealth mode, which is denoted by
the DND toggle being enabled (and persisted among reboots).

When antiraid mode is enabled, the bot behaves diferently, such as
rejecting requests to validate an account if neccessary.

Note that at the moment the antiraid mode is global.