### PR TITLE
feat: remove messages that match invite codes

### DIFF
--- a/src/Makibot.ts
+++ b/src/Makibot.ts
@@ -9,6 +9,7 @@ import RosterService from "./hooks/roster";
 import VerifyService from "./hooks/verify";
 import WarnService from "./hooks/warn";
 import AntiRaid from "./lib/antiraid";
+import AntispamService from "./hooks/antispam";
 
 export default class Makibot extends Commando.CommandoClient {
   readonly antiraid: AntiRaid;
@@ -45,6 +46,7 @@ export default class Makibot extends Commando.CommandoClient {
           new RosterService(this);
           new VerifyService(this);
           new WarnService(this);
+          new AntispamService(this);
 
           // Init the antiraid engine.
           this.antiraid.init();

--- a/src/hooks/antispam.ts
+++ b/src/hooks/antispam.ts
@@ -1,0 +1,47 @@
+import { Message } from "discord.js";
+import Member from "../lib/member";
+import { WastebinModlogEvent } from "../lib/modlog";
+import Server from "../lib/server";
+import Makibot from "../Makibot";
+import Hook from "./hook";
+
+function containsInvite(message: Message): boolean {
+  const tokens = ["discord.gg/", "discordapp.com/invite/", "discord.com/invite"];
+  return tokens.some((token) => message.content.includes(token));
+}
+
+function isAllowed(message: Message): boolean {
+  const member = new Member(message.member);
+  return member.moderator;
+}
+
+export default class AntispamService implements Hook {
+  private client: Makibot;
+
+  constructor(client: Makibot) {
+    this.client = client;
+
+    this.client.on("message", (message) => this.message(message));
+  }
+
+  private async message(message: Message): Promise<void> {
+    if (containsInvite(message) && !isAllowed(message)) {
+      /* Handle invite. */
+      const member = message.member.id;
+      const channel = message.channel;
+      await message.delete();
+      await channel.send(
+        "Se ha retenido automáticamente el mensaje de %s porque se ha detectado un enlace de invitación.".replace(
+          "%s",
+          `<@${member}>`
+        )
+      );
+
+      /* Send message to the modlog. */
+      const server = new Server(message.guild);
+      server
+        .logModlogEvent(new WastebinModlogEvent(message))
+        .catch((e) => console.error(`Error during wastebin handler: ${e}`));
+    }
+  }
+}

--- a/src/hooks/verify.ts
+++ b/src/hooks/verify.ts
@@ -8,9 +8,8 @@ import Member from "../lib/member";
 
 /* The message that will be replied to members that type the token during cooldown period. */
 const TOO_SOON = [
-  "%s, has dicho la palabra secreta correcta, pero para poder verificarte necesito",
-  "que permanezcas unos minutos en el servidor antes de volver a intentar enviarla.",
-  "(Esto también se avisa en las normas, ¿seguro que las has leído?)",
+  "%s, has dicho la palabra secreta correcta, pero como dicen las normas del servidor,",
+  "tienes que permanecer unos minutos para que sea atendida y se pueda validar la cuenta.",
 ].join(" ");
 
 /* The message that will be replied to members that successfully validate their accounts. */
@@ -58,10 +57,10 @@ export default class VerifyService implements Hook {
         if (this.client.antiraid.raidMode) {
           await sendOutcome(MANUAL, message);
         } else {
-        /* Send the message first, as setting the role may inhibit future events about the channel */
-        await sendOutcome(ACCEPTED, message);
-        await member.setVerification(true);
-        await server.logModlogEvent(new VerifyModlogEvent(message.member));
+          /* Send the message first, as setting the role may inhibit future events about the channel */
+          await sendOutcome(ACCEPTED, message);
+          await member.setVerification(true);
+          await server.logModlogEvent(new VerifyModlogEvent(message.member));
         }
       } else {
         await sendOutcome(TOO_SOON, message);


### PR DESCRIPTION
This commit will automatically remove messages that contain links
including discord.gg, discord.com/invite and discordapp.com/invite. If
the message is sent to a captchas channel, the member is automatically
banned.