### PR TITLE
refactor: remove trusted roles

### DIFF
--- a/src/hooks/antiflood.ts
+++ b/src/hooks/antiflood.ts
@@ -62,7 +62,7 @@ export default class AntifloodService implements Hook {
     const normalized = normalize(message.cleanContent);
 
     /* Some cases that are allowed. */
-    if (message.author.bot || !member.verified || member.trusted || member.moderator) {
+    if (message.author.bot || !member.verified || member.moderator) {
       return;
     }
     if (words(message.cleanContent).length <= 3) {

--- a/src/hooks/antispam.ts
+++ b/src/hooks/antispam.ts
@@ -67,7 +67,7 @@ function isAllowed(message: Message): boolean {
     return true;
   } else {
     const member = new Member(message.member);
-    return member.crew || member.trusted || member.moderator;
+    return member.crew || member.moderator;
   }
 }
 
@@ -85,7 +85,7 @@ export default class AntispamService implements Hook {
 
   private async message(message: Message): Promise<void> {
     if (isAllowed(message)) {
-      return; /* trusted member or bot */
+      return; /* mod or bot */
     }
     const match = testModeration(message);
     if (match) {

--- a/src/hooks/karma.ts
+++ b/src/hooks/karma.ts
@@ -220,7 +220,7 @@ export default class KarmaService implements Hook {
         highScoreLevel.set(expectedLevel);
 
         /* A temporal fix to avoid spamming messages to most existing members. */
-        if (!member.trusted || expectedLevel > 1) {
+        if (expectedLevel > 1) {
           channel.send(getLevelUpMessage(gm.id, expectedLevel));
         }
       }

--- a/src/lib/http/middlewares/member.ts
+++ b/src/lib/http/middlewares/member.ts
@@ -46,7 +46,6 @@ export default function memberMiddleware(makibot: Makibot): express.Router {
       moderator: member.moderator,
       status: {
         verified: member.verified,
-        trusted: member.trusted,
         warned: member.warned,
         helper: member.helper,
         canPostLinks: member.canPostLinks,

--- a/src/lib/member.ts
+++ b/src/lib/member.ts
@@ -73,10 +73,6 @@ export default class Member {
     return this.hasRole(this.server.modsRole);
   }
 
-  get trusted(): boolean {
-    return this.hasRole(this.server.trustedRole);
-  }
-
   get warned(): boolean {
     return this.hasRole(this.server.warnRole);
   }

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -162,11 +162,6 @@ export default class Server {
     return this.getRoleByName(warnRoleName);
   }
 
-  get trustedRole(): Role {
-    const trustedRoleName = process.env.TRUSTED_ROLE || "trusted";
-    return this.getRoleByName(trustedRoleName);
-  }
-
   get linksDisabledRole(): Role {
     const linksDisabledRole = process.env.LINKS_DISABLE_ROLE || "links-disabled";
     return this.getRoleByName(linksDisabledRole);


### PR DESCRIPTION
trusted role was deprecated in favour of the karma level. One can assume
that members with level 2 or above are trusted and tests that assert who
is sending the message could use the level to signal allowed members.