### PR TITLE
feat: KarmaV2

### DIFF
--- a/spec/lib/karma.spec.ts
+++ b/spec/lib/karma.spec.ts
@@ -1,24 +1,28 @@
 import { expect } from "chai";
 import "mocha";
 
-import { getLevel } from "../../src/lib/karma";
+import { getLevelV2 } from "../../src/lib/karma";
 
 describe("karma", () => {
-  describe("#getLevel", () => {
+  describe("#getLevelV2", () => {
     it("works for positives", () => {
-      expect(getLevel(1)).to.eq(1);
-      expect(getLevel(49)).to.eq(1);
-      expect(getLevel(50)).to.eq(2);
+      expect(getLevelV2(1)).to.eq(1);
+      expect(getLevelV2(29)).to.eq(1);
+      expect(getLevelV2(30)).to.eq(2);
+      expect(getLevelV2(50)).to.eq(2);
+      expect(getLevelV2(61)).to.eq(3);
+      expect(getLevelV2(3879)).to.eq(49);
+      expect(getLevelV2(3890)).to.eq(50);
     });
 
     it("works for negatives", () => {
-      expect(getLevel(-1)).to.eq(-1);
-      expect(getLevel(-49)).to.eq(-1);
-      expect(getLevel(-50)).to.eq(-2);
+      expect(getLevelV2(-1)).to.eq(-1);
+      expect(getLevelV2(-29)).to.eq(-1);
+      expect(getLevelV2(-30)).to.eq(-2);
     });
 
     it("works for zero", () => {
-      expect(getLevel(0)).to.eq(0);
+      expect(getLevelV2(0)).to.eq(0);
     });
   });
 });

--- a/src/hooks/karma.ts
+++ b/src/hooks/karma.ts
@@ -205,23 +205,23 @@ export default class KarmaService implements Hook {
           `Has sido silenciado automáticamente, <@${gm.user.id}>`,
           "Silenciado automáticamente al tener karma excesivamente negativo"
         );
-        alreadyWarnedTag.set(true);
+        await alreadyWarnedTag.set(true);
       }
     }
 
     const currentLevel = member.tagbag.tag("karma:level");
     const expectedLevel = getLevelV2(karma.points);
     if (currentLevel.get(0) != expectedLevel) {
-      currentLevel.set(expectedLevel);
+      await currentLevel.set(expectedLevel);
 
       const highScoreLevel = member.tagbag.tag("karma:max");
       if (highScoreLevel.get(0) < expectedLevel) {
-        highScoreLevel.set(expectedLevel);
-        channel.send(getLevelUpMessage(gm.id, expectedLevel));
+        await highScoreLevel.set(expectedLevel);
+        await channel.send(getLevelUpMessage(gm.id, expectedLevel));
       }
     }
 
     /* Update presence in the tiers. */
-    member.setCrew(currentLevel.get(0));
+    await member.setCrew(currentLevel.get(0));
   }
 }

--- a/src/lib/http/middlewares/member.ts
+++ b/src/lib/http/middlewares/member.ts
@@ -5,7 +5,7 @@ import { MiddlewareLocals as GuildMiddlewareLocals } from "./guild";
 
 import Member from "../../member";
 import Makibot from "../../../Makibot";
-import { getLevel } from "../../karma";
+import { getLevelV1, getLevelV2 } from "../../karma";
 
 export interface MiddlewareLocals extends GuildMiddlewareLocals {
   guildMember: GuildMember;
@@ -77,6 +77,14 @@ export default function memberMiddleware(makibot: Makibot): express.Router {
     if (isNaN(offset) || offset < 0) {
       res.status(400).contentType("text/plain").send("Offset must be a positive number");
     } else {
+      /* Generation. */
+      const karmagen = res.locals.member.tagbag.tag("karma:ver").get<string>("v1");
+      const levelFormulas = {
+        v1: getLevelV1,
+        v2: getLevelV2,
+      };
+      const getLevel = levelFormulas[karmagen];
+
       /* Bump the offset. */
       await res.locals.member.tagbag.tag("karma:offset").set(offset);
 

--- a/src/lib/karma.ts
+++ b/src/lib/karma.ts
@@ -18,7 +18,7 @@ export function getLevelUpMessage(id: Snowflake, level: number): string {
   }
 }
 
-export function getLevel(points: number): number {
+export function getLevelV1(points: number): number {
   /*
    * Considerations:
    * - Always add 1 because it is not possible to have level 0, you always start from level 1.
@@ -40,4 +40,38 @@ export function getLevel(points: number): number {
     const progress = Math.pow(points / 50, 1 / 1.25);
     return Math.trunc(progress) + 1;
   }
+}
+
+export function getLevelV2(points: number): number {
+  /*
+   * Formula:  XP = OFFT * (LVL-1)^(1 + LVL/MULT)
+   * Where: OFFT = 30 and MULT = 200
+   *
+   * Rationale: KarmaV2 alters the offset (goes down from 50 to 30)
+   * and also changes the exponent so that it is higher once the
+   * level goes up.
+   *
+   * Screw inverse formulas, this formula is so complex that I prefer
+   * to build a loop that iterates until the desired level gets
+   * computed.
+   *
+   * TODO: Can this be memoized?
+   */
+  if (points === 0) {
+    return 0;
+  } else if (points < 0) {
+    return -1 * getLevelV2(-points);
+  }
+
+  const offset = 30;
+  const mult = 200;
+
+  let pts,
+    level = 0;
+  do {
+    level++;
+    pts = Math.ceil(offset * Math.pow(level - 1, 1 + level / mult));
+  } while (pts <= points);
+
+  return level - 1;
 }

--- a/src/lib/member.ts
+++ b/src/lib/member.ts
@@ -145,10 +145,15 @@ export default class Member {
   }
 
   async upgradeKarma(): Promise<void> {
-    const karma = await this.getKarma();
-    if (karma.version === "v1") {
+    const version = this.tagbag.tag("karma:ver").get<string>("v1");
+
+    if (version === "v1") {
       /* Upgrade to v2. */
-      const levelV2 = getLevelV2(karma.points);
+      const total = await this.client.karma.count(this.id);
+      const offset = this.tagbag.tag("karma:offset").get(0);
+      const points = total + offset;
+
+      const levelV2 = getLevelV2(points);
       await this.tagbag.tag("karma:level").set(levelV2);
       await this.tagbag.tag("karma:max").set(levelV2);
       await this.tagbag.tag("karma:ver").set("v2");

--- a/src/lib/member.ts
+++ b/src/lib/member.ts
@@ -14,6 +14,7 @@ interface KarmaStats {
   points: number;
   level: number;
   total: number;
+  version: string;
 }
 
 export default class Member {
@@ -118,6 +119,7 @@ export default class Member {
     const [total, messages, upvotes, downvotes, stars, hearts, waves] = results;
     const offset = this.tagbag.tag("karma:offset").get(0);
     const level = this.tagbag.tag("karma:level").get(1);
+    const version = this.tagbag.tag("karma:ver").get<string>("v1");
     const points = offset + total;
 
     return {
@@ -131,6 +133,7 @@ export default class Member {
       upvotes,
       waves,
       total,
+      version,
     };
   }
 


### PR DESCRIPTION
KarmaV2 introduces an enhanced formula for calculating karma.

Prior revision of the formula (KarmaV1) didn't have the deltas properly calibrated, thus it was easier to level up after reaching a threshold than for new members. This new formula makes easier to level up for new members, but makes it harder after a member reaches level 65.

In the following graph, Delta1 represents the amount of messages required to jump from level X-1 to level X using the previous formula, and Delta2 represents the same amount using the new formula.

![imagen](https://user-images.githubusercontent.com/1568690/125534126-7875db26-6c10-4c06-8188-7c385478140a.png)

It can be seen that DeltaV1 had issues because it required a big effort on the low levels, but this effort doesn't get harder for higher level, making the karma level very lineal.

The new formula is exponential but the exponent is proportional to the level, thus the exponent is bigger on high levels. As a result, it is easier to level up for new members, but the amount of XP points required to level up grows after a threshold.

![imagen](https://user-images.githubusercontent.com/1568690/125534288-e99bbc2c-05d5-40a8-8ecd-92e2ede0204c.png)

Those above level 73 using KarmaV1 will probably lose levels, while those below level 73 will gain levels.