### PR TITLE
refactor: extract sendResponse into its own function

### DIFF
--- a/src/lib/interaction.ts
+++ b/src/lib/interaction.ts
@@ -13,6 +13,27 @@ import RaidCommand from "../interactions/commands/raid";
 import Makibot from "../Makibot";
 import InteractionCommand from "./interaction/basecommand";
 import logger from "./logger";
+import axios from "axios";
+
+export async function sendResponse(event: APIGuildInteraction, response: string, ephemeral: boolean = false): Promise<void> {
+  const payload: any = {
+    type: 4,
+    data: { content: response },
+  };
+  if (ephemeral) {
+    payload.data.flags = 64;
+  }
+  logger.debug("[interactions] sending response: ", payload);
+  return axios.post(
+    `https://discord.com/api/v8/interactions/${event.id}/${event.token}/callback`,
+    payload,
+    {
+      headers: {
+      "Content-Type": "application/json",
+    },
+  },
+  );
+}
 
 interface HandlerConstructor {
   // https://stackoverflow.com/a/39614325/2033517

--- a/src/lib/interaction.ts
+++ b/src/lib/interaction.ts
@@ -13,27 +13,6 @@ import RaidCommand from "../interactions/commands/raid";
 import Makibot from "../Makibot";
 import InteractionCommand from "./interaction/basecommand";
 import logger from "./logger";
-import axios from "axios";
-
-export async function sendResponse(event: APIGuildInteraction, response: string, ephemeral: boolean = false): Promise<void> {
-  const payload: any = {
-    type: 4,
-    data: { content: response },
-  };
-  if (ephemeral) {
-    payload.data.flags = 64;
-  }
-  logger.debug("[interactions] sending response: ", payload);
-  return axios.post(
-    `https://discord.com/api/v8/interactions/${event.id}/${event.token}/callback`,
-    payload,
-    {
-      headers: {
-      "Content-Type": "application/json",
-    },
-  },
-  );
-}
 
 interface HandlerConstructor {
   // https://stackoverflow.com/a/39614325/2033517

--- a/src/lib/interaction/basecommand.ts
+++ b/src/lib/interaction/basecommand.ts
@@ -14,7 +14,7 @@ export default abstract class InteractionCommand<Params> {
   abstract name: string;
   abstract handle(params?: Params): Promise<void>;
 
-  sendResponse(response: string, ephemeral: boolean = false): Promise<void> {
+  sendResponse(response: string, ephemeral = false): Promise<void> {
     return sendResponse(this.event, response, ephemeral);
   }
 }

--- a/src/lib/interaction/basecommand.ts
+++ b/src/lib/interaction/basecommand.ts
@@ -1,6 +1,6 @@
 import { APIGuildInteraction } from "discord-api-types";
 import Makibot from "../../Makibot";
-import { sendResponse } from "../interaction";
+import { sendResponse } from "./response";
 
 export default abstract class InteractionCommand<Params> {
   protected readonly client: Makibot;

--- a/src/lib/interaction/basecommand.ts
+++ b/src/lib/interaction/basecommand.ts
@@ -1,14 +1,6 @@
-import axios from "axios";
 import { APIGuildInteraction } from "discord-api-types";
 import Makibot from "../../Makibot";
-import logger from "../logger";
-
-const interactionsClient = axios.create({
-  baseURL: "https://discord.com/api/v8",
-  headers: {
-    "Content-Type": "application/json",
-  },
-});
+import { sendResponse } from "../interaction";
 
 export default abstract class InteractionCommand<Params> {
   protected readonly client: Makibot;
@@ -23,17 +15,6 @@ export default abstract class InteractionCommand<Params> {
   abstract handle(params?: Params): Promise<void>;
 
   sendResponse(response: string, ephemeral: boolean = false): Promise<void> {
-    const payload: any = {
-      type: 4,
-      data: { content: response },
-    };
-    if (ephemeral) {
-      payload.data.flags = 64;
-    }
-    logger.debug("[interactions] sending response: ", payload);
-    return interactionsClient.post(
-      `/interactions/${this.event.id}/${this.event.token}/callback`,
-      payload
-    );
+    return sendResponse(this.event, response, ephemeral);
   }
 }

--- a/src/lib/interaction/response.ts
+++ b/src/lib/interaction/response.ts
@@ -1,9 +1,13 @@
 import axios from "axios";
-import { APIGuildInteraction } from "discord-api-types";
+import { APIGuildInteraction, APIInteractionResponse } from "discord-api-types";
 import logger from "../logger";
 
-export async function sendResponse(event: APIGuildInteraction, response: string, ephemeral: boolean = false): Promise<void> {
-  const payload: any = {
+export async function sendResponse(
+  event: APIGuildInteraction,
+  response: string,
+  ephemeral = false
+): Promise<void> {
+  const payload: APIInteractionResponse = {
     type: 4,
     data: { content: response },
   };
@@ -16,8 +20,8 @@ export async function sendResponse(event: APIGuildInteraction, response: string,
     payload,
     {
       headers: {
-      "Content-Type": "application/json",
-    },
-  },
+        "Content-Type": "application/json",
+      },
+    }
   );
 }

--- a/src/lib/interaction/response.ts
+++ b/src/lib/interaction/response.ts
@@ -1,0 +1,23 @@
+import axios from "axios";
+import { APIGuildInteraction } from "discord-api-types";
+import logger from "../logger";
+
+export async function sendResponse(event: APIGuildInteraction, response: string, ephemeral: boolean = false): Promise<void> {
+  const payload: any = {
+    type: 4,
+    data: { content: response },
+  };
+  if (ephemeral) {
+    payload.data.flags = 64;
+  }
+  logger.debug("[interactions] sending response: ", payload);
+  return axios.post(
+    `https://discord.com/api/v8/interactions/${event.id}/${event.token}/callback`,
+    payload,
+    {
+      headers: {
+      "Content-Type": "application/json",
+    },
+  },
+  );
+}


### PR DESCRIPTION
This will make possible to reply to interactions even when there is not a class behind the interaction handler.

See https://github.com/makigas/clank/pull/360 for an use case for this. This PR is a cherry-pick of a few of the commits in that branch.