### PR TITLE
refactor: wrap command manipulations in a client

### DIFF
--- a/src/interactions/commands/desresponder.ts
+++ b/src/interactions/commands/desresponder.ts
@@ -1,31 +1,11 @@
-import axios from "axios";
-import { Guild, Snowflake } from "discord.js";
+import { Guild } from "discord.js";
 import Server from "../../lib/server";
 import InteractionCommand from "../../lib/interaction/basecommand";
 import type { ResponderParams } from "./responder";
+import { deleteGuildCommand, getGuildCommand } from "../../lib/interaction/client";
 
 interface DesresponderParams {
   nombre: string;
-}
-
-async function getCommandId(
-  app: Snowflake,
-  guild: Snowflake,
-  name: string
-): Promise<Snowflake | null> {
-  const request = await axios.get(
-    `https://discord.com/api/v8/applications/${app}/guilds/${guild}/commands`,
-    { headers: { Authorization: `Bot ${process.env.BOT_TOKEN}` } }
-  );
-  const command = request.data.find((command: { name: string }) => command.name === name);
-  return command ? command.id : null;
-}
-
-async function deleteCommand(app: Snowflake, guild: Snowflake, command: Snowflake): Promise<void> {
-  await axios.delete(
-    `https://discord.com/api/v8/applications/${app}/guilds/${guild}/commands/${command}`,
-    { headers: { Authorization: `Bot ${process.env.BOT_TOKEN}` } }
-  );
 }
 
 /*
@@ -51,14 +31,17 @@ export default class DesresponderCommand extends InteractionCommand<Desresponder
     const currentCommands: { [name: string]: ResponderParams } = replyCommands.get({});
 
     if (params && params.nombre in currentCommands) {
-      const app = await this.client.fetchApplication();
-      const commandId = await getCommandId(app.id, guild.id, params.nombre);
-      if (commandId) {
-        await deleteCommand(app.id, guild.id, commandId);
+      const command = await getGuildCommand(guild, params.nombre);
+      if (command) {
+        /* The command is found, ready to delete it. */
+        deleteGuildCommand(guild, command.id);
+        await this.sendResponse("Comando ha sido eliminado", true);
+      } else {
+        /* The command is not found, but we delete it from the array. */
+        await this.sendResponse("Comando ha sido retirado", true);
       }
       delete currentCommands[params.nombre];
       await replyCommands.set(currentCommands);
-      await this.sendResponse("Comando ha sido eliminado", true);
     } else {
       await this.sendResponse("Este comando no existe", true);
     }

--- a/src/interactions/commands/responder.ts
+++ b/src/interactions/commands/responder.ts
@@ -1,8 +1,8 @@
-import { Guild, Snowflake } from "discord.js";
+import { Guild } from "discord.js";
 import Server from "../../lib/server";
 import InteractionCommand from "../../lib/interaction/basecommand";
-import axios from "axios";
 import { APIApplicationCommandOption, ApplicationCommandOptionType } from "discord-api-types";
+import { createGuildCommand } from "../../lib/interaction/client";
 
 const commandParamType: { [kind: string]: ApplicationCommandOptionType } = {
   string: ApplicationCommandOptionType.String,
@@ -43,25 +43,6 @@ export interface ResponderParams {
   efimero: boolean;
   respuesta: string;
   params: string;
-}
-
-async function registerReply(
-  app: Snowflake,
-  guild: Snowflake,
-  name: string,
-  commandParams: APIApplicationCommandOption[]
-): Promise<void> {
-  await axios.post(
-    `https://discord.com/api/v8/applications/${app}/guilds/${guild}/commands`,
-    {
-      name,
-      description: `Ejecuta comando ${name}`,
-      options: commandParams || [],
-    },
-    {
-      headers: { Authorization: `Bot ${process.env.BOT_TOKEN}` },
-    }
-  );
 }
 
 /*
@@ -115,10 +96,8 @@ export default class ResponderCommand extends InteractionCommand<ResponderParams
     currentCommands[params.nombre] = params;
 
     /* Fetch the APP_ID for this bot. */
-    const application = await this.client.fetchApplication();
-    const applicationId = application.id;
     const commandParams = parseCommandArguments(params.params);
-    await registerReply(applicationId, guild.id, params.nombre, commandParams);
+    await createGuildCommand(guild, params.nombre, commandParams);
 
     /* Register the command. */
     replyCommands.set(currentCommands);

--- a/src/lib/interaction/client.ts
+++ b/src/lib/interaction/client.ts
@@ -42,7 +42,7 @@ export async function createGuildCommand(
  */
 export async function getGuildCommand(guild: Guild, name: string): Promise<APIApplicationCommand> {
   const application = await guild.client.fetchApplication();
-  const url = `/v8/applications/${application.id}/guilds/${guild.id}/commands`;
+  const url = `/applications/${application.id}/guilds/${guild.id}/commands`;
   return client
     .get<RESTGetAPIApplicationGuildCommandsResult>(url)
     .then((resp) => resp.data.find((cmd) => cmd.name === name));
@@ -55,6 +55,6 @@ export async function getGuildCommand(guild: Guild, name: string): Promise<APIAp
  */
 export async function deleteGuildCommand(guild: Guild, id: Snowflake): Promise<void> {
   const application = await guild.client.fetchApplication();
-  const url = `/v8/applications/${application.id}/guilds/${guild.id}/commands/${id}`;
+  const url = `/applications/${application.id}/guilds/${guild.id}/commands/${id}`;
   await client.delete(url);
 }

--- a/src/lib/interaction/client.ts
+++ b/src/lib/interaction/client.ts
@@ -1,0 +1,60 @@
+import axios from "axios";
+import {
+  APIApplicationCommand,
+  APIApplicationCommandOption,
+  RESTGetAPIApplicationGuildCommandsResult,
+  RESTPostAPIApplicationGuildCommandsJSONBody,
+} from "discord-api-types/v9";
+import { Guild, Snowflake } from "discord.js";
+
+const client = axios.create({
+  baseURL: "https://discord.com/api/v8/",
+  headers: { Authorization: `Bot ${process.env.BOT_TOKEN}` },
+});
+
+/**
+ * Creates a local command bound to a specific guild.
+ * @param guild the guild where the command will be bound to
+ * @param name the name of the command that will be created
+ * @param options the options array for the local command
+ * @returns a promise that resolves unless there is an error
+ */
+export async function createGuildCommand(
+  guild: Guild,
+  name: string,
+  options: APIApplicationCommandOption[]
+): Promise<void> {
+  const application = await guild.client.fetchApplication();
+  const url = `/applications/${application.id}/guilds/${guild.id}/commands`;
+  const payload: RESTPostAPIApplicationGuildCommandsJSONBody = {
+    name,
+    description: `Ejecuta el comando ${name} en este servidor`,
+    options,
+  };
+  await client.post(url, payload);
+}
+
+/**
+ * Fetches a command given its name.
+ * @param guild the guild there the local command exists
+ * @param name the name of the command that will be retrieved
+ * @returns a promise that resolves to the command behind this name
+ */
+export async function getGuildCommand(guild: Guild, name: string): Promise<APIApplicationCommand> {
+  const application = await guild.client.fetchApplication();
+  const url = `/v8/applications/${application.id}/guilds/${guild.id}/commands`;
+  return client
+    .get<RESTGetAPIApplicationGuildCommandsResult>(url)
+    .then((resp) => resp.data.find((cmd) => cmd.name === name));
+}
+
+/**
+ * Deletes a local command given its identifier.
+ * @param guild the guild where the local command exists.
+ * @param id the identifier of the command to delete.
+ */
+export async function deleteGuildCommand(guild: Guild, id: Snowflake): Promise<void> {
+  const application = await guild.client.fetchApplication();
+  const url = `/v8/applications/${application.id}/guilds/${guild.id}/commands/${id}`;
+  await client.delete(url);
+}


### PR DESCRIPTION
This commit will organize all the API calls that deal with local command
creation and manipulation and merge them into a single module called
client, to execute those HTTP requests.