### PR TITLE
fix: catch errors during command interactions

### DIFF
--- a/src/lib/interaction.ts
+++ b/src/lib/interaction.ts
@@ -118,7 +118,14 @@ export async function handleInteraction(client: Makibot, event: APIInteraction):
       const parameters = event.data.options
         ? await convertParameters(event.data.options, guild)
         : {};
-      handler.handle(guild, parameters);
+
+      handler.handle(guild, parameters).catch((e) => {
+        logger.error("[interactions] command failed with a generic error", event.data, e);
+        const owners = client.owners.map((owner) => `<@${owner.id}>`).join(", ");
+        const check = client.owners.length > 1 ? "revisad" : "revisa";
+        const error = `API Error: el comando ha fallado. Por favor, ${owners}, ${check} los logs`;
+        return handler.sendResponse(error);
+      });
     } else if (replies[event.data.name]) {
       /* A local command with this name exists, so send the response. */
       const data = replies[event.data.name];


### PR DESCRIPTION
When a command fails, this change will make a generic interaction
response at least acknowledge that there has been an error, and also log
the error to the bot stderr, so that an operator can later check out the
logs.