### PR TITLE
chore(deps): bump Node version to 14

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,36 +1,36 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "00:00"
-  open-pull-requests-limit: 99
-  labels:
-  - dependencies
-  ignore:
-  - dependency-name: "@types/node"
-    versions:
-    - ">= 13"
-  - dependency-name: discord.js-commando
-    versions:
-    - ">= 0.12.0"
-  commit-message:
-    prefix: chore
-    include: scope
-- package-ecosystem: docker
-  directory: "/"
-  schedule:
-    interval: weekly
-    day: saturday
-    time: "00:00"
-  open-pull-requests-limit: 99
-  labels:
-  - dependencies
-  ignore:
-  - dependency-name: node
-    versions:
-    - ">= 13"
-  commit-message:
-    prefix: chore
-    include: scope
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "00:00"
+    open-pull-requests-limit: 99
+    labels:
+      - dependencies
+    ignore:
+      - dependency-name: "@types/node"
+        versions:
+          - ">= 15"
+      - dependency-name: discord.js-commando
+        versions:
+          - ">= 0.12.0"
+    commit-message:
+      prefix: chore
+      include: scope
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: saturday
+      time: "00:00"
+    open-pull-requests-limit: 99
+    labels:
+      - dependencies
+    ignore:
+      - dependency-name: node
+        versions:
+          - ">= 13"
+    commit-message:
+      prefix: chore
+      include: scope

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "12"
+          node-version: "14"
       - run: npm install
       - run: npm test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # CLANK DOCKERFILE 🤖
 # made with ❤️ by your friends at makigas
 
-FROM node:12-alpine
+FROM node:14-alpine
 RUN mkdir /clank
 WORKDIR /clank
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Requirements
 
-- We target Node 12.
+- We target Node 14.
 - A Discord application that can behave as a bot.
 - A Discord server.
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "typescript": "^4.3.5"
   },
   "engines": {
-    "node": ">=12.0 <14.0"
+    "node": ">=14.0 <15.0"
   },
   "files": [
     "contrib/",


### PR DESCRIPTION
Discord.js 13 will require Node 14 to work. Thus, this commit will bump
the Node version to 14. It should work since I've accidentally
discovered that I've been working these last few months with Node v14 in
one of my machines instead of the nodenv v12.
