### PR TITLE
feat: new response embeds for hooks and interactions

### DIFF
--- a/src/hooks/antiflood.ts
+++ b/src/hooks/antiflood.ts
@@ -1,6 +1,7 @@
 import { GuildPreview, Message, PartialMessage } from "discord.js";
 import { Hook } from "../lib/hook";
 import Member from "../lib/member";
+import { createToast } from "../lib/response";
 import applyWastebin from "../lib/wastebin";
 import Makibot from "../Makibot";
 
@@ -75,9 +76,21 @@ export default class AntifloodService implements Hook {
     if (normalized in history) {
       const when = history[normalized];
       if (Date.now() - when < 3600_000) {
-        await message.channel.send(
-          `Enviar el mismo mensaje múltiples veces se considera flooding.\nEstá prohibido en este servidor, <@${message.member.id}>, así que no lo hagas.`
-        );
+        const toast = createToast({
+          title: `@${message.member.user.username}, no hagas flooding`,
+          severity: "warning",
+          target: message.member.user,
+          description: [
+            "Ponte de acuerdo y elige un canal en el que mandar tu mensaje.",
+            "No mandes el mismo mensaje a múltiples canales porque puede ser",
+            "confuso para las personas que te pueden estar intentando echar",
+            "una mano, ¿no crees?",
+            "\n\n",
+            "Tendrás que borrar el mensaje del otro canal si quieres mandarlo",
+            "aquí, o esperar una hora para que el mensaje se enfríe.",
+          ].join(" "),
+        });
+        await message.channel.send(toast);
         await applyWastebin(message);
       }
     }

--- a/src/hooks/karma.ts
+++ b/src/hooks/karma.ts
@@ -9,9 +9,10 @@ import {
   User,
 } from "discord.js";
 import { Hook } from "../lib/hook";
-import { canReceivePoints, getLevelV2, getLevelUpMessage } from "../lib/karma";
+import { canReceivePoints, getLevelV2 } from "../lib/karma";
 import { KarmaDatabase } from "../lib/karma/database";
 import Member from "../lib/member";
+import { createToast } from "../lib/response";
 import Server from "../lib/server";
 import { notifyPublicModlog } from "../lib/warn";
 import Makibot from "../Makibot";
@@ -217,7 +218,27 @@ export default class KarmaService implements Hook {
       const highScoreLevel = member.tagbag.tag("karma:max");
       if (highScoreLevel.get(0) < expectedLevel) {
         await highScoreLevel.set(expectedLevel);
-        await channel.send(getLevelUpMessage(gm.id, expectedLevel));
+        if (expectedLevel === 1) {
+          /* First message. */
+          const toast = createToast({
+            title: `¡Es el primer mensaje de @${gm.user.username}!`,
+            description: [
+              `Parece que este es el primer mensaje de @${gm.user.username} en este servidor.`,
+              "¡Te damos la bienvenida, este servidor es mejor ahora que estás aquí!",
+              "Pásalo bien y disfruta en la comunidad.",
+            ].join(" "),
+            severity: "success",
+            target: gm.user,
+          });
+          await channel.send(toast);
+        } else {
+          const toast = createToast({
+            title: `¡@${gm.user.username} ha subido al nivel ${expectedLevel}!`,
+            severity: "success",
+            target: gm.user,
+          });
+          await channel.send(toast);
+        }
       }
     }
 

--- a/src/hooks/tombstone.ts
+++ b/src/hooks/tombstone.ts
@@ -2,11 +2,9 @@ import { Message, PartialMessage, TextChannel } from "discord.js";
 import Tag from "../lib/tag";
 import Makibot from "../Makibot";
 import { Hook } from "../lib/hook";
+import { createToast } from "../lib/response";
 
 const STALE_HOURS = 24;
-
-const TOMBSTONE_TEXT = `👻 _[un mensaje ha sido borrado]_ 👻
-    (por eso este canal te sale como no leído)`;
 
 /**
  * Fetch the tag that may yield to the ID of a message acting as a tombstone
@@ -98,7 +96,17 @@ export default class TombstoneService implements Hook {
     const staleness = STALE_HOURS * 3600 * 1000;
     if (messages.first().createdTimestamp < Date.now() - staleness) {
       /* It is. Send a tombstone. */
-      const tombstone = await channel.send(TOMBSTONE_TEXT);
+      const toast = createToast({
+        title: "Un mensaje ha sido eliminado",
+        description: [
+          `Como el mensaje que tengo justo encima tiene más de 24 horas, mando`,
+          `esta notificación para no confundir a quienes vean que hay mensajes nuevos`,
+          `en este canal y no los encuentren.`,
+        ].join(" "),
+        severity: "info",
+        thumbnail: `https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/120/twitter/282/ghost_1f47b.png`,
+      });
+      const tombstone = await message.channel.send(toast);
       tombstoneTag(channel).set(tombstone.id);
     }
   }

--- a/src/interactions/commands/desresponder.ts
+++ b/src/interactions/commands/desresponder.ts
@@ -3,6 +3,7 @@ import Server from "../../lib/server";
 import InteractionCommand from "../../lib/interaction/basecommand";
 import type { ResponderParams } from "./responder";
 import { deleteGuildCommand, getGuildCommand } from "../../lib/interaction/client";
+import { createToast } from "../../lib/response";
 
 interface DesresponderParams {
   nombre: string;
@@ -35,15 +36,27 @@ export default class DesresponderCommand extends InteractionCommand<Desresponder
       if (command) {
         /* The command is found, ready to delete it. */
         deleteGuildCommand(guild, command.id);
-        await this.sendResponse("Comando ha sido eliminado", true);
+        const toast = createToast({
+          title: "El comando ha sido eliminado con éxito",
+          severity: "success",
+        });
+        await this.sendResponse({ embed: toast, ephemeral: true });
       } else {
-        /* The command is not found, but we delete it from the array. */
-        await this.sendResponse("Comando ha sido retirado", true);
+        /* Use a different message to signal the error to clever users. */
+        const toast = createToast({
+          title: "El comando ha sido eliminado del sistema del bot",
+          severity: "success",
+        });
+        await this.sendResponse({ embed: toast, ephemeral: true });
       }
       delete currentCommands[params.nombre];
       await replyCommands.set(currentCommands);
     } else {
-      await this.sendResponse("Este comando no existe", true);
+      const toast = createToast({
+        title: "Comando no encontrado",
+        severity: "error",
+      });
+      await this.sendResponse({ embed: toast, ephemeral: true });
     }
   }
 }

--- a/src/interactions/commands/karma.ts
+++ b/src/interactions/commands/karma.ts
@@ -1,6 +1,7 @@
 import InteractionCommand from "../../lib/interaction/basecommand";
 import Server from "../../lib/server";
 import { getPointsForLevelV2 } from "../../lib/karma";
+import { createToast } from "../../lib/response";
 
 /*
   {
@@ -19,20 +20,28 @@ export default class KarmaCommand extends InteractionCommand<{}> {
     const stats = await member.getKarma();
     const nextLevel = getPointsForLevelV2(stats.level + 1);
 
+    const toast = createToast({
+      title: `Balance de karma de @${member.user.username}`,
+      target: member.user,
+      severity: "info",
+    });
+    toast.addField("🪙 Karma", stats.points, true);
+    toast.addField("🏅 Nivel", stats.level, true);
+    toast.addField("💬 Mensajes", stats.messages, true);
+    if (stats.offset > 0) {
+      toast.addField("⏩ Offset", stats.offset, true);
+    }
+    toast.addField("🔜 Puntos hasta el siguiente nivel", nextLevel - stats.points, false);
+
     const kinds = [
       `👍 ${stats.upvotes}`,
       `👎 ${stats.downvotes}`,
       `⭐ ${stats.stars}`,
       `❤️ ${stats.hearts}`,
       `👋 ${stats.waves}`,
-    ];
+    ].join(" / ");
+    toast.addField("Reacciones", kinds, false);
 
-    const response =
-      `🪙 Karma: ${stats.points}        🏅 Nivel: ${stats.level}\n` +
-      `  💬 Mensajes: ${stats.messages}        ⏩ Offset: ${stats.offset}\n` +
-      `  🔜 Siguiente nivel en: ${nextLevel - stats.points}\n` +
-      `  ${kinds.join("    ")}`;
-
-    this.sendResponse(response, true);
+    this.sendResponse({ embed: toast, ephemeral: true });
   }
 }

--- a/src/interactions/commands/primo.ts
+++ b/src/interactions/commands/primo.ts
@@ -1,6 +1,7 @@
 import bigInt, { BigInteger } from "big-integer";
 import { Guild } from "discord.js";
 import InteractionCommand from "../../lib/interaction/basecommand";
+import { createToast } from "../../lib/response";
 
 interface PrimoParams {
   n: string;
@@ -23,20 +24,27 @@ interface PrimoParams {
 export default class PrimoCommand extends InteractionCommand<PrimoParams> {
   name: string = "primo";
 
+  private sendToast(title: string): Promise<void> {
+    return this.sendResponse({
+      embed: createToast({
+        title,
+        severity: "info",
+      }),
+    });
+  }
+
   handle(_guild: Guild, params: PrimoParams): Promise<void> {
-    if (params.n.trim() == "") {
-      return this.sendResponse("Uso: `/primo [n:number]`", true);
-    } else if (/^\-?\d+$/g.test(params.n)) {
+    if (/^\-?\d+$/g.test(params.n)) {
       let prime = bigInt(params.n);
       if (this.isPrime(prime)) {
-        return this.sendResponse(`Se da la circunstancia de que sí, ${prime} es primo.`, false);
+        return this.sendToast(`Informamos que ${prime} es un número primo`);
       } else if (prime.mod(2).eq(0)) {
-        return this.sendResponse("Amigo, deberías saber que un par no puede ser primo.", false);
+        return this.sendToast(`Deberías saber que un par nunca puede ser primo`);
       } else {
-        return this.sendResponse(`No, ${prime} no es primo.`, false);
+        return this.sendToast(`No, ${prime} no es un número primo`);
       }
     } else {
-      return this.sendResponse(`\`${params.n}\` no es exactamente un número`, false);
+      return this.sendToast(`"${params.n}" no es exactamente un número`);
     }
   }
 

--- a/src/interactions/commands/raid.ts
+++ b/src/interactions/commands/raid.ts
@@ -1,6 +1,6 @@
-import { APIGuildInteraction } from "discord-api-types";
 import { Guild } from "discord.js";
 import InteractionCommand from "../../lib/interaction/basecommand";
+import { createToast } from "../../lib/response";
 
 interface RaidParameters {
   "raid-mode": boolean;
@@ -36,9 +36,10 @@ export default class RaidCommand extends InteractionCommand<RaidParameters> {
 
   async handle(_guild: Guild, params: RaidParameters): Promise<void> {
     await this.client.antiraid.setRaidMode(params["raid-mode"]);
-    await this.sendResponse(
-      params["raid-mode"] ? "Modo raid activado" : "Modo raid desactivado",
-      true
-    );
+    const toast = createToast({
+      title: `El modo raid ha sido ${params["raid-mode"] ? "activado" : "desactivado"}`,
+      severity: "info",
+    });
+    await this.sendResponse({ embed: toast, ephemeral: true });
   }
 }

--- a/src/interactions/commands/responder.ts
+++ b/src/interactions/commands/responder.ts
@@ -3,6 +3,7 @@ import Server from "../../lib/server";
 import InteractionCommand from "../../lib/interaction/basecommand";
 import { APIApplicationCommandOption, ApplicationCommandOptionType } from "discord-api-types";
 import { createGuildCommand } from "../../lib/interaction/client";
+import { createToast } from "../../lib/response";
 
 const commandParamType: { [kind: string]: ApplicationCommandOptionType } = {
   string: ApplicationCommandOptionType.String,
@@ -86,10 +87,13 @@ export default class ResponderCommand extends InteractionCommand<ResponderParams
     const currentCommands: { [name: string]: ResponderParams } = replyCommands.get({});
 
     if (currentCommands[params.nombre]) {
-      await this.sendResponse(
-        "Este comando ya está creado, bórralo antes o dale otro nombre",
-        true
-      );
+      const toast = createToast({
+        title: "No se puede crear el comando",
+        description:
+          "Un comando con el mismo nombre ya existe. Deberá ser borrado antes o usar otro nombre.",
+        severity: "error",
+      });
+      await this.sendResponse({ embed: toast, ephemeral: true });
       return;
     }
 
@@ -101,7 +105,10 @@ export default class ResponderCommand extends InteractionCommand<ResponderParams
 
     /* Register the command. */
     replyCommands.set(currentCommands);
-
-    this.sendResponse("Comando ha sido creado", true);
+    const toast = createToast({
+      title: "Comando creado correctamente",
+      severity: "success",
+    });
+    await this.sendResponse({ embed: toast, ephemeral: true });
   }
 }

--- a/src/lib/interaction.ts
+++ b/src/lib/interaction.ts
@@ -22,6 +22,7 @@ import InteractionCommand from "./interaction/basecommand";
 import logger from "./logger";
 import Server from "./server";
 import { sendResponse } from "./interaction/response";
+import { createToast } from "./response";
 
 interface HandlerConstructor {
   // https://stackoverflow.com/a/39614325/2033517
@@ -121,10 +122,13 @@ export async function handleInteraction(client: Makibot, event: APIInteraction):
 
       handler.handle(guild, parameters).catch((e) => {
         logger.error("[interactions] command failed with a generic error", event.data, e);
-        const owners = client.owners.map((owner) => `<@${owner.id}>`).join(", ");
-        const check = client.owners.length > 1 ? "revisad" : "revisa";
-        const error = `API Error: el comando ha fallado. Por favor, ${owners}, ${check} los logs`;
-        return handler.sendResponse(error);
+        return handler.sendResponse({
+          embed: createToast({
+            title: "API Error: el comando ha fallado",
+            description: "Un administrador encontrará más información en los logs de la aplicación",
+            severity: "error",
+          }),
+        });
       });
     } else if (replies[event.data.name]) {
       /* A local command with this name exists, so send the response. */
@@ -167,7 +171,9 @@ export async function handleInteraction(client: Makibot, event: APIInteraction):
         }
       }, data.respuesta);
 
-      await sendResponse(event, interpolatedResponse, data.efimero);
+      await sendResponse(event, {
+        content: interpolatedResponse,
+      });
     }
   }
 }

--- a/src/lib/interaction/basecommand.ts
+++ b/src/lib/interaction/basecommand.ts
@@ -1,7 +1,7 @@
 import { APIGuildInteraction } from "discord-api-types";
 import { Guild } from "discord.js";
 import Makibot from "../../Makibot";
-import { sendResponse } from "./response";
+import { ResponseOptions, sendResponse } from "./response";
 
 export default abstract class InteractionCommand<Params> {
   protected readonly client: Makibot;
@@ -15,7 +15,7 @@ export default abstract class InteractionCommand<Params> {
   abstract name: string;
   abstract handle(guild: Guild, params?: Params): Promise<void>;
 
-  sendResponse(response: string, ephemeral = false): Promise<void> {
-    return sendResponse(this.event, response, ephemeral);
+  sendResponse(options: ResponseOptions): Promise<void> {
+    return sendResponse(this.event, options);
   }
 }

--- a/src/lib/interaction/response.ts
+++ b/src/lib/interaction/response.ts
@@ -1,19 +1,41 @@
 import axios from "axios";
-import { APIGuildInteraction, APIInteractionResponse } from "discord-api-types";
+import { APIEmbed, APIGuildInteraction, APIInteractionResponse } from "discord-api-types/v9";
+import { MessageEmbed, MessageEmbedOptions } from "discord.js";
 import logger from "../logger";
+
+function translateEmbed(embed: MessageEmbed | MessageEmbedOptions): APIEmbed {
+  /* Only the properties that this bot use. */
+  const payload: APIEmbed = {
+    title: embed.title,
+    description: embed.description,
+    thumbnail: embed.thumbnail,
+    author: embed.author,
+    fields: embed.fields,
+  };
+  if (embed.color) {
+    payload.color = embed.color as number;
+  }
+  return payload;
+}
+
+export interface ResponseOptions {
+  embed?: MessageEmbed | MessageEmbedOptions;
+  ephemeral?: boolean;
+  content?: string;
+}
 
 export async function sendResponse(
   event: APIGuildInteraction,
-  response: string,
-  ephemeral = false
+  response: ResponseOptions
 ): Promise<void> {
   const payload: APIInteractionResponse = {
     type: 4,
-    data: { content: response },
+    data: {
+      content: response.content,
+      embeds: response.embed ? [translateEmbed(response.embed)] : [],
+      flags: response.ephemeral ? 64 : 0,
+    },
   };
-  if (ephemeral) {
-    payload.data.flags = 64;
-  }
   logger.debug("[interactions] sending response: ", payload);
   return axios.post(
     `https://discord.com/api/v8/interactions/${event.id}/${event.token}/callback`,

--- a/src/lib/karma.ts
+++ b/src/lib/karma.ts
@@ -1,4 +1,4 @@
-import { GuildMember, Snowflake } from "discord.js";
+import { GuildMember } from "discord.js";
 import Member from "./member";
 
 export function canReceivePoints(gm: GuildMember): boolean {
@@ -7,15 +7,6 @@ export function canReceivePoints(gm: GuildMember): boolean {
   }
   const member = new Member(gm);
   return !gm.user.bot && member.verified;
-}
-
-export function getLevelUpMessage(id: Snowflake, level: number): string {
-  switch (level) {
-    case 1:
-      return `¡Te damos la bienvenida, <@${id}>! Este servidor es mejor ahora que estás aquí. Has publicado tu primer mensaje y por eso has subido a Nivel 1. Interactúa en este servidor para subir de nivel y desbloquear funciones nuevas.`;
-    default:
-      return `¡Enhorabuena, <@${id}>, has alcanzado el Nivel ${level}`;
-  }
 }
 
 export function getLevelV1(points: number): number {

--- a/src/lib/member.ts
+++ b/src/lib/member.ts
@@ -1,4 +1,4 @@
-import { GuildMember, Role } from "discord.js";
+import { GuildMember, Role, User } from "discord.js";
 import Makibot from "../Makibot";
 import { getLevelV2 } from "./karma";
 import Server from "./server";
@@ -28,6 +28,10 @@ export default class Member {
   constructor(guildMember: GuildMember) {
     this.guildMember = guildMember;
     this.server = new Server(this.guildMember.guild);
+  }
+
+  get user(): User {
+    return this.guildMember.user;
   }
 
   private hasRole(role: Role | null | undefined): boolean {

--- a/src/lib/response.ts
+++ b/src/lib/response.ts
@@ -5,6 +5,7 @@ import {
   MessageOptions,
   NewsChannel,
   TextChannel,
+  User,
 } from "discord.js";
 
 function permalink(message: Message): string {
@@ -55,4 +56,46 @@ export function quoteMessage(message: Message): MessageOptions {
     embed: quote,
     files,
   };
+}
+
+const SEVERITIES = {
+  info: {
+    color: 0x0d6efd,
+  },
+  success: {
+    color: 0x198754,
+  },
+  error: {
+    color: 0xdc3545,
+  },
+  warning: {
+    color: 0xffc107,
+  },
+};
+
+type Severity = keyof typeof SEVERITIES;
+
+interface NotificationOptions {
+  title: string;
+  description?: string;
+  severity?: Severity;
+  target?: User;
+  thumbnail?: string;
+}
+
+export function createToast(options: NotificationOptions): MessageEmbed {
+  const embed = new MessageEmbed();
+  if (options.target) {
+    embed.setAuthor(options.title, options.target.avatarURL());
+  } else {
+    embed.setAuthor(options.title);
+  }
+  if (options.description) {
+    embed.setDescription(options.description);
+  }
+  if (options.thumbnail) {
+    embed.setThumbnail(options.thumbnail);
+  }
+  embed.setColor(SEVERITIES[options.severity || "warning"].color);
+  return embed;
 }


### PR DESCRIPTION
Toasts are notifications built using embeds, that have a uniform look
and feel and consistent style. It also wraps the parameters so that in
the future, upgrading the bot to newer Discord.js versions organizes
better the breaking changes to avoid having to rewrite code in a lot of
areas.

In this PR, toasts are added for hooks and interactions responses.

![imagen](https://user-images.githubusercontent.com/1568690/127579599-c482b2b5-6fea-438c-9c65-ef6e1c6de065.png)

![imagen](https://user-images.githubusercontent.com/1568690/127579745-16ef5273-a4e2-480c-b841-4e157e67be3a.png)

![imagen](https://user-images.githubusercontent.com/1568690/127579611-3043463f-9618-424e-a1b7-ce38c244abcc.png)

![imagen](https://user-images.githubusercontent.com/1568690/127579622-8fa44477-572b-42e9-ae6d-5a9f7e73d140.png)

![imagen](https://user-images.githubusercontent.com/1568690/127579629-b8d145ba-e0f8-4155-bfda-185eba639e96.png)

![imagen](https://user-images.githubusercontent.com/1568690/127579645-14a66a62-1116-4f24-997a-f0ed89194308.png)

![imagen](https://user-images.githubusercontent.com/1568690/127579661-039c2126-10b9-47a9-b38f-2e0a7d6b0548.png)
