### PR TITLE
fix: provider fails to setup on new bots

### DIFF
--- a/src/lib/provider.ts
+++ b/src/lib/provider.ts
@@ -13,7 +13,9 @@ export class SettingProvider {
   private cache: { [server: string]: object };
 
   constructor(private db: Database, private client: Client) {
-    this.cache = {};
+    this.cache = {
+      "global": {},
+    };
   }
 
   async init(): Promise<void> {
@@ -29,6 +31,9 @@ export class SettingProvider {
   }
 
   get(guild: Snowflake | "global", key: string, defaultValue: any = undefined): any {
+    if (!this.cache[guildToCacheName(guild)]) {
+      
+    }
     return this.cache[guildToCacheName(guild)][key] || defaultValue;
   }
 


### PR DESCRIPTION
Because the cache does not create the global cache, it might fail if the
settings.db file did not exist previously.
