### PR TITLE
refactor: clean the hooks

### DIFF
--- a/src/hooks/antiflood.ts
+++ b/src/hooks/antiflood.ts
@@ -4,7 +4,6 @@ import Member from "../lib/member";
 import { createToast } from "../lib/response";
 import applyWastebin from "../lib/wastebin";
 import applyWarn from "../lib/warn";
-import Makibot from "../Makibot";
 
 function generateFirstToast(message: Message): MessageEmbed {
   return createToast({
@@ -92,30 +91,10 @@ async function raisePing(member: Member): Promise<number> {
   return recentPings.length;
 }
 
-async function prefetchMessage(message: Message | PartialMessage): Promise<Message> {
-  if (message.partial) {
-    return message.fetch();
-  } else {
-    return message as Message;
-  }
-}
-
 export default class AntifloodService implements Hook {
   name = "antiflood";
 
-  constructor(private client: Makibot) {
-    client.on("message", (message) => this.handleMessage(message));
-    client.on("messageDelete", (message) =>
-      prefetchMessage(message).then((message) => this.handleDelete(message))
-    );
-    client.on("messageDeleteBulk", (messages) =>
-      messages.forEach((message) =>
-        prefetchMessage(message).then((message) => this.handleDelete(message))
-      )
-    );
-  }
-
-  private async handleDelete(message: Message): Promise<void> {
+  async onMessageDestroy(message: PartialMessage): Promise<void> {
     if (!message.member || !message.member.guild) {
       /* Webhooks will trigger this. */
       return;
@@ -130,7 +109,7 @@ export default class AntifloodService implements Hook {
     await tag.set(cleanHistory(history));
   }
 
-  private async handleMessage(message: Message): Promise<void> {
+  async onMessageCreate(message: Message): Promise<void> {
     if (!message.member || !message.member.guild) {
       /* Webhooks will trigger this. */
       return;

--- a/src/hooks/antispam.ts
+++ b/src/hooks/antispam.ts
@@ -23,9 +23,7 @@ const ruleset: { [reason: string]: RegExp[] } = {
     /steamcommunity.com\/id\/\w+/, // Steam profile pages by vanity URL.
     /steamcommunity.com\/profiles\/\w+/, // Steam profile pages by ID.
   ],
-  "El enlace apunta a una tienda de aplicaciones": [
-    /play.google.com\/store\/apps\/details/,
-  ],
+  "El enlace apunta a una tienda de aplicaciones": [/play.google.com\/store\/apps\/details/],
   "El enlace apunta a un Google Doc": [
     /docs.google.com\/document\/d\//, // Google Docs
     /docs.google.com\/spreadsheets\/d\//, // Google Docs
@@ -82,8 +80,6 @@ function isAllowed(message: Message): boolean {
     return member.crew || member.moderator;
   }
 }
-
-const NOTIFY = "(Se ha retenido el mensaje de %s: %s.)";
 
 export default class AntispamService implements Hook {
   name = "antispam";

--- a/src/hooks/antispam.ts
+++ b/src/hooks/antispam.ts
@@ -4,7 +4,6 @@ import getUrls from "get-urls";
 import Member from "../lib/member";
 import { WastebinModlogEvent } from "../lib/modlog";
 import Server from "../lib/server";
-import Makibot from "../Makibot";
 import { Hook } from "../lib/hook";
 import { createToast } from "../lib/response";
 
@@ -89,14 +88,7 @@ const NOTIFY = "(Se ha retenido el mensaje de %s: %s.)";
 export default class AntispamService implements Hook {
   name = "antispam";
 
-  private client: Makibot;
-
-  constructor(client: Makibot) {
-    this.client = client;
-    this.client.on("message", (message) => this.message(message));
-  }
-
-  private async message(message: Message): Promise<void> {
+  async onMessageCreate(message: Message): Promise<void> {
     if (isAllowed(message)) {
       return; /* mod or bot */
     }

--- a/src/hooks/csgo.ts
+++ b/src/hooks/csgo.ts
@@ -51,11 +51,6 @@ const TOKENS = [
 export default class CsgoService implements Hook {
   name = "csgo";
 
-  constructor(private client: Client) {
-    this.handleMessage = this.handleMessage.bind(this);
-    this.client.on("message", this.handleMessage);
-  }
-
   private async handleMatch(message: Message, member: Member): Promise<void> {
     /* Warn and mute the participant. */
     await applyWarn(message.guild, {
@@ -78,7 +73,7 @@ export default class CsgoService implements Hook {
     await message.delete();
   }
 
-  private async handleMessage(message: Message): Promise<void> {
+  async onMessageCreate(message: Message): Promise<void> {
     if (message.guild) {
       const server = new Server(message.guild);
       const member = await server.member(message.author.id);

--- a/src/hooks/csgo.ts
+++ b/src/hooks/csgo.ts
@@ -1,4 +1,4 @@
-import { Client, Message } from "discord.js";
+import { Message } from "discord.js";
 import { Hook } from "../lib/hook";
 import Member from "../lib/member";
 import { createToast } from "../lib/response";

--- a/src/hooks/csgo.ts
+++ b/src/hooks/csgo.ts
@@ -11,6 +11,7 @@ import applyWarn from "../lib/warn";
 
 const TOKENS = [
   // Different variations of steamcommunity.
+  /steamcommmunlity.com/,
   /steamcconuunity.co/,
   /steamcomminutiu.ru/,
   /steamcomminytiy.ru/,
@@ -30,6 +31,7 @@ const TOKENS = [
   /stermccommunitty.ru/,
   /stiemcommunitty.ru/,
   /steamcommrnunity.com/,
+  /steamcommunity.link/,
 
   // There is this CSGO scam-bot
   /https:\/\/prnt.sc\//,
@@ -43,9 +45,28 @@ const TOKENS = [
   /dlscord.ink/,
   /dlscord.pro/,
   /dlscord.nitro/,
+  /discortnitosteam.online/,
 
-  // TODO: Should I just ban ".ru/" entirely?
-  // /.ru\//,
+  // Update
+  /rust-way.com/,
+  /twitch.rust-ltd.com/,
+  /:\/\/discord-nitro./,
+  /discorcl.link/,
+  /discorcl.click/,
+  /discordapp.click/,
+  /discordapp.link/,
+
+  // I don't have time for this shit
+  /discorcl.[a-z]/,
+  /dlscord.[a-z]/,
+  /discordapp.[abd-z]/,
+
+  // risky, but i think worth
+  /get 3 months/,
+  /get 1 month/,
+  /3 months of discord nitro/,
+  /.ru\//,
+  /.ru.com\//,
 ];
 
 export default class CsgoService implements Hook {

--- a/src/hooks/csgo.ts
+++ b/src/hooks/csgo.ts
@@ -73,7 +73,7 @@ const TOKENS = [
   // I don't have time for this shit
   /discorcl.[a-z]/,
   /dlscord.[a-z]/,
-  /discordapp.[abd-z]/,
+  /discordapp.([abd-mo-z]|c[a-n][p-z]|n[a-df-z])/,
 
   // risky, but i think worth
   /get 3 months/,

--- a/src/hooks/karma.ts
+++ b/src/hooks/karma.ts
@@ -1,10 +1,8 @@
 import {
-  Channel,
   GuildMember,
   Message,
   MessageReaction,
   PartialMessage,
-  PartialUser,
   TextBasedChannels,
   TextChannel,
   User,
@@ -18,23 +16,12 @@ import Server from "../lib/server";
 import { notifyPublicModlog } from "../lib/warn";
 import Makibot from "../Makibot";
 
-async function prefetchMessage(message: Message | PartialMessage): Promise<Message> {
-  if (message.partial) {
-    await message.fetch();
-  }
-  return message as Message;
-}
-
-async function prefetchUser(user: User | PartialUser): Promise<User> {
-  if (user.partial) {
-    return user.fetch();
-  } else {
-    return user as User;
-  }
-}
-
 function isTextChannel(channel: TextBasedChannels): channel is TextChannel {
-  return channel.type == "GUILD_TEXT" || channel.type == "GUILD_PUBLIC_THREAD" || channel.type === "GUILD_NEWS";
+  return (
+    channel.type == "GUILD_TEXT" ||
+    channel.type == "GUILD_PUBLIC_THREAD" ||
+    channel.type === "GUILD_NEWS"
+  );
 }
 
 const REACTIONS: { [reaction: string]: { kind: string; score: number } } = {
@@ -63,9 +50,7 @@ const REACTIONS: { [reaction: string]: { kind: string; score: number } } = {
 export default class KarmaService implements Hook {
   name = "karma";
 
-  constructor(private bot: Makibot) {
-    
-  }
+  constructor(private bot: Makibot) {}
 
   /* Made as a getter so that we can defer accessing the karma db until the very last moment. */
   private get karma(): KarmaDatabase {

--- a/src/hooks/pin.ts
+++ b/src/hooks/pin.ts
@@ -1,10 +1,9 @@
-import type { Message, MessageReaction, PartialMessage, Snowflake, TextChannel, User } from "discord.js";
+import type { Message, MessageReaction, PartialMessage, Snowflake, TextChannel } from "discord.js";
 import { Hook } from "../lib/hook";
 import logger from "../lib/logger";
 import { quoteMessage } from "../lib/response";
 import Server from "../lib/server";
 import type Tag from "../lib/tag";
-import type Makibot from "../Makibot";
 
 /* Get the tag that would persist the pin for this message. */
 function pinTag(message: Message | PartialMessage): Tag | null {
@@ -46,10 +45,9 @@ function delegatesToPin(reaction: MessageReaction): boolean {
 }
 
 export default class PinService implements Hook {
-
   name = "pin";
 
-  async onMessageReactionAdd(reaction: MessageReaction, _user: User): Promise<void> {
+  async onMessageReactionAdd(reaction: MessageReaction): Promise<void> {
     try {
       await reaction.fetch();
 
@@ -76,7 +74,7 @@ export default class PinService implements Hook {
     }
   }
 
-  async onMessageReactionDestroy(reaction: MessageReaction, _user: User): Promise<void> {
+  async onMessageReactionDestroy(reaction: MessageReaction): Promise<void> {
     try {
       await reaction.fetch();
       if (delegatesToPin(reaction) && reaction.count === 0) {

--- a/src/hooks/pin.ts
+++ b/src/hooks/pin.ts
@@ -1,4 +1,4 @@
-import type { Message, MessageReaction, PartialMessage, Snowflake, TextChannel } from "discord.js";
+import type { Message, MessageReaction, PartialMessage, Snowflake, TextChannel, User } from "discord.js";
 import { Hook } from "../lib/hook";
 import logger from "../lib/logger";
 import { quoteMessage } from "../lib/response";
@@ -46,23 +46,10 @@ function delegatesToPin(reaction: MessageReaction): boolean {
 }
 
 export default class PinService implements Hook {
-  private client: Makibot;
 
   name = "pin";
 
-  constructor(client: Makibot) {
-    this.client = client;
-
-    this.addReaction = this.addReaction.bind(this);
-    this.removeReaction = this.removeReaction.bind(this);
-    this.removeAllReactions = this.removeAllReactions.bind(this);
-
-    this.client.on("messageReactionAdd", this.addReaction);
-    this.client.on("messageReactionRemove", this.removeReaction);
-    this.client.on("messageReactionRemoveAll", this.removeAllReactions);
-  }
-
-  private async addReaction(reaction: MessageReaction): Promise<void> {
+  async onMessageReactionAdd(reaction: MessageReaction, _user: User): Promise<void> {
     try {
       await reaction.fetch();
 
@@ -89,7 +76,7 @@ export default class PinService implements Hook {
     }
   }
 
-  private async removeReaction(reaction: MessageReaction): Promise<void> {
+  async onMessageReactionDestroy(reaction: MessageReaction, _user: User): Promise<void> {
     try {
       await reaction.fetch();
       if (delegatesToPin(reaction) && reaction.count === 0) {
@@ -100,7 +87,7 @@ export default class PinService implements Hook {
     }
   }
 
-  private async removeAllReactions(message: Message | PartialMessage): Promise<void> {
+  async onMessageReactionBulkDestroy(message: Message): Promise<void> {
     try {
       const richMessage = await message.fetch();
       if (isPinneable(richMessage)) {

--- a/src/hooks/quote.ts
+++ b/src/hooks/quote.ts
@@ -1,8 +1,7 @@
-import { NewsChannel, TextChannel } from "discord.js";
+import { Message, NewsChannel, TextChannel } from "discord.js";
 import { Hook } from "../lib/hook";
 import logger from "../lib/logger";
 import { quoteMessage } from "../lib/response";
-import Makibot from "../Makibot";
 
 function permalink(content: string) {
   const regex = /discord\.com\/channels\/([0-9]+)\/([0-9]+)\/([0-9]+)/;
@@ -12,8 +11,8 @@ function permalink(content: string) {
 export default class QuoteService implements Hook {
   name = "quote";
 
-  constructor(private client: Makibot) {
-    this.client.on("message", async (originalMessage) => {
+  async onMessageCreate(originalMessage: Message): Promise<void> {
+    {
       const ids = permalink(originalMessage.cleanContent);
       if (ids) {
         try {
@@ -43,6 +42,6 @@ export default class QuoteService implements Hook {
           logger.error("[quote] cannot send message", e);
         }
       }
-    });
+    }
   }
 }

--- a/src/hooks/quote.ts
+++ b/src/hooks/quote.ts
@@ -3,7 +3,7 @@ import { Hook } from "../lib/hook";
 import logger from "../lib/logger";
 import { quoteMessage } from "../lib/response";
 
-function permalink(content: string) {
+function permalink(content: string): RegExpMatchArray {
   const regex = /discord\.com\/channels\/([0-9]+)\/([0-9]+)\/([0-9]+)/;
   return content.match(regex);
 }
@@ -16,7 +16,7 @@ export default class QuoteService implements Hook {
       const ids = permalink(originalMessage.cleanContent);
       if (ids) {
         try {
-          const [_, guildId, channelId, messageId] = ids;
+          const [guildId, channelId, messageId] = ids.slice(1);
           if (originalMessage.guild || originalMessage.guild.id === guildId) {
             const channel = originalMessage.guild.channels.cache.get(channelId);
             if (channel) {

--- a/src/hooks/roster.ts
+++ b/src/hooks/roster.ts
@@ -1,18 +1,9 @@
-import { GuildMember, Guild, User, PartialGuildMember } from "discord.js";
+import { GuildMember } from "discord.js";
 
 import { Hook } from "../lib/hook";
-import Makibot from "../Makibot";
 import { JoinModlogEvent, LeaveModlogEvent, BanModlogEvent } from "../lib/modlog";
 import Server from "../lib/server";
 import logger from "../lib/logger";
-
-async function resolvePartial(member: GuildMember | PartialGuildMember): Promise<GuildMember> {
-  if (member.partial) {
-    return member.fetch();
-  } else {
-    return member as GuildMember;
-  }
-}
 
 /**
  * The roster sends announces to the modlog channel as a result of some events,
@@ -22,15 +13,7 @@ async function resolvePartial(member: GuildMember | PartialGuildMember): Promise
 export default class RosterService implements Hook {
   name = "roster";
 
-  constructor(client: Makibot) {
-    client.on("guildMemberAdd", (member) => this.memberJoin(member));
-    client.on("guildMemberRemove", (member) =>
-      resolvePartial(member).then((member) => this.memberLeft(member))
-    );
-    client.on("guildBanAdd", (ban) => this.memberBan(ban.guild, ban.user));
-  }
-
-  private async memberBan(guild: Guild, user: User): Promise<void> {
+  async onGuildMemberBan({guild, user}): Promise<void> {
     logger.debug(`[roster] announcing ban for ${user.tag}`);
     try {
       const server = new Server(guild);
@@ -40,7 +23,7 @@ export default class RosterService implements Hook {
     }
   }
 
-  private async memberJoin(member: GuildMember): Promise<void> {
+  async onGuildMemberJoin(member: GuildMember): Promise<void> {
     logger.debug(`[roster] announcing join for ${member.user.tag}`);
     try {
       const server = new Server(member.guild);
@@ -50,7 +33,7 @@ export default class RosterService implements Hook {
     }
   }
 
-  private async memberLeft(member: GuildMember): Promise<void> {
+  async onGuildMemberLeave(member: GuildMember): Promise<void> {
     logger.debug(`[roster] announcing leave for ${member.user.tag}`);
     try {
       const server = new Server(member.guild);

--- a/src/hooks/roster.ts
+++ b/src/hooks/roster.ts
@@ -1,4 +1,4 @@
-import { GuildMember } from "discord.js";
+import { GuildBan, GuildMember } from "discord.js";
 
 import { Hook } from "../lib/hook";
 import { JoinModlogEvent, LeaveModlogEvent, BanModlogEvent } from "../lib/modlog";
@@ -13,7 +13,7 @@ import logger from "../lib/logger";
 export default class RosterService implements Hook {
   name = "roster";
 
-  async onGuildMemberBan({guild, user}): Promise<void> {
+  async onGuildMemberBan({ guild, user }: GuildBan): Promise<void> {
     logger.debug(`[roster] announcing ban for ${user.tag}`);
     try {
       const server = new Server(guild);

--- a/src/hooks/tombstone.ts
+++ b/src/hooks/tombstone.ts
@@ -43,25 +43,10 @@ async function getTombstone(channel: TextChannel): Promise<Message | null> {
   }
 }
 
-async function resolveMessage(message: Message | PartialMessage): Promise<Message> {
-  if (message.partial) {
-    return message.fetch();
-  } else {
-    return message as Message;
-  }
-}
-
 export default class TombstoneService implements Hook {
   name = "tombstone";
 
-  constructor(client: Makibot) {
-    client.on("messageDelete", (message) =>
-      resolveMessage(message).then((message) => this.onMessageDelete(message))
-    );
-    client.on("message", (message) => this.onMessageCreate(message));
-  }
-
-  private async onMessageCreate(message: Message): Promise<void> {
+  async onMessageCreate(message: Message): Promise<void> {
     const channel = message.channel as TextChannel;
 
     /* Discard messages not sent to a guild. */
@@ -82,7 +67,7 @@ export default class TombstoneService implements Hook {
     }
   }
 
-  private async onMessageDelete(message: Message): Promise<void> {
+  async onMessageDestroy(message: PartialMessage): Promise<void> {
     const channel = message.channel as TextChannel;
 
     /* Discard messages not sent to a guild. */

--- a/src/hooks/verify.ts
+++ b/src/hooks/verify.ts
@@ -22,9 +22,7 @@ function isVerificationMessage(message: Message): boolean {
 export default class VerifyService implements Hook {
   name = "verify";
 
-  constructor(private client: Makibot) {
-    
-  }
+  constructor(private client: Makibot) {}
 
   async onMessageCreate(message: Message): Promise<void> {
     const server = new Server(message.guild);

--- a/src/hooks/verify.ts
+++ b/src/hooks/verify.ts
@@ -23,10 +23,10 @@ export default class VerifyService implements Hook {
   name = "verify";
 
   constructor(private client: Makibot) {
-    client.on("message", (message) => this.handleMessage(message));
+    
   }
 
-  private async handleMessage(message: Message): Promise<void> {
+  async onMessageCreate(message: Message): Promise<void> {
     const server = new Server(message.guild);
 
     if (server.captchasChannel?.id == message.channel.id && isVerificationMessage(message)) {

--- a/src/hooks/voicerole.ts
+++ b/src/hooks/voicerole.ts
@@ -22,9 +22,6 @@ export default class VoiceRoleService implements Hook {
   constructor(private client: Makibot) {
     const voiceRoleConfig = client.provider.get(null, "voiceroles", {});
     this.voicerole = new VoiceRole(voiceRoleConfig);
-    this.client.on("voiceStateUpdate", (oldState, newState) =>
-      this.triggerVoiceStateUpdate(oldState, newState)
-    );
   }
 
   triggerVoiceStateUpdate(oldState: VoiceState, newState: VoiceState): void {

--- a/src/hooks/warn.ts
+++ b/src/hooks/warn.ts
@@ -18,17 +18,7 @@ function isMessageWarned(message: Message): boolean {
 export default class WarnService implements Hook {
   name = "warn";
 
-  private client: Makibot;
-
-  constructor(client: Makibot) {
-    this.client = client;
-
-    this.client.on("messageReactionAdd", async (reaction, user) => {
-      const fetchedReaction = await reaction.fetch();
-      const fetchedUser = await user.fetch();
-      this.messageReactionAdd(fetchedReaction, fetchedUser);
-    });
-
+  constructor(private client: Makibot) {
     this.restoreOldTimeouts();
   }
 
@@ -48,7 +38,7 @@ export default class WarnService implements Hook {
     });
   }
 
-  private async messageReactionAdd(reaction: MessageReaction, user: User): Promise<void> {
+  async onMessageReactionAdd(reaction: MessageReaction, user: User): Promise<void> {
     await reaction.fetch();
     const message = reaction.message as Message;
 

--- a/src/lib/hook.ts
+++ b/src/lib/hook.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+import { GuildBan, GuildMember, Message, MessageReaction, PartialGuildMember, PartialMessage, User, VoiceState } from "discord.js";
 import requireAll from "require-all";
 import Makibot from "../Makibot";
 import logger from "./logger";
@@ -12,6 +13,20 @@ export interface Hook {
 
   /** Callback to ask the hook to restart itself. */
   restart?: () => void;
+
+  onMessageCreate?: (message: Message) => Promise<void>;
+  onMessageUpdate?: (message: Message) => Promise<void>;
+  onMessageDestroy?: (message: PartialMessage) => Promise<void>;
+
+  onMessageReactionAdd?: (reaction: MessageReaction, user: User) => Promise<void>;
+  onMessageReactionDestroy?: (reaction: MessageReaction, user: User) => Promise<void>;
+  onMessageReactionBulkDestroy?: (message: Message) => Promise<void>;
+
+  onGuildMemberJoin?: (member: GuildMember) => Promise<void>;
+  onGuildMemberLeave?: (member: GuildMember) => Promise<void>;
+  onGuildMemberBan?: (ban: GuildBan) => Promise<void>;
+
+  onVoiceStateUpdate?: (oldStatus: VoiceState, newStatus: VoiceState) => Promise<void>;
 }
 
 export class HookManager {
@@ -24,6 +39,8 @@ export class HookManager {
       filter: /^([^.].*)\.[jt]s$/,
     });
 
+    const instances: Hook[] = []
+
     Object.values(hooks).forEach((hook) => {
       if (hook.default && typeof hook.default === "function") {
         /* close ES module resolution. */
@@ -31,15 +48,80 @@ export class HookManager {
       }
 
       const instance: Hook = new hook(client);
+      instances.push(instance)
       if (instance.allowsRestart) {
         this.watchdog[instance.name] = instance;
       }
       logger.debug(`[hooks] registering service ${instance.name}`);
     });
     logger.debug("[hooks] finished registering services");
+
+    client.on("messageCreate", (message: Message) => {
+      instances.filter(i => !!i.onMessageCreate).map(i => {
+        logger.debug(`[hooks] processing messageCreate via ${i.name}`);
+        return i.onMessageCreate(message);
+      });
+    });
+    client.on("messageDelete", (message: PartialMessage) => {
+      instances.filter(i => !!i.onMessageDestroy).map(i => {
+        logger.debug(`[hooks] processing messageDestroy via ${i.name}`);
+        return i.onMessageDestroy(message);
+      });
+    });
+    client.on("messageReactionAdd", (reaction, user) => {
+      Promise.all([reaction.fetch(), user.fetch()]).then(([reaction, user]) => {
+        instances.filter(i => !!i.onMessageReactionAdd).map(i => {
+          logger.debug(`[hooks] processing messageReactionAdd via ${i.name}`);
+        return i.onMessageReactionAdd(reaction, user);
+        });
+      });
+    });
+    client.on("messageReactionRemove", (reaction, user) => {
+      Promise.all([reaction.fetch(), user.fetch()]).then(([reaction, user]) => {
+        instances.filter(i => !!i.onMessageReactionDestroy).map(i => {
+          logger.debug(`[hooks] processing messageReactionRemove via ${i.name}`);
+          return i.onMessageReactionDestroy(reaction, user);
+        });
+      });
+    });
+    client.on("messageReactionRemoveAll", (message) => {
+      message.fetch().then((message) => {
+        instances.filter(i => !!i.onMessageReactionBulkDestroy).map(i => {
+          logger.debug(`[hooks] processing messageReactionRemoveAll via ${i.name}`);
+          return i.onMessageReactionBulkDestroy(message);
+        });
+      });
+    });
+    client.on("guildMemberAdd", (member) => {
+      instances.filter(i => !!i.onGuildMemberJoin).map(i => {
+        logger.debug(`[hooks] processing guildMemberAdd via ${i.name}`);
+        return i.onGuildMemberJoin(member);
+      });
+    });
+    client.on("guildMemberRemove", (member) => {
+      member.fetch().then((member) => {
+        instances.filter(i => !!i.onGuildMemberLeave).map(i => {
+          logger.debug(`[hooks] processing guildMemberAdd via ${i.name}`);
+          return i.onGuildMemberLeave(member);
+        });
+      });
+    });
+    client.on("guildBanAdd", (ban) => {
+      instances.filter(i => !!i.onGuildMemberBan).map(i => {
+        logger.debug(`[hooks] processing guildBanAdd via ${i.name}`);
+        return i.onGuildMemberBan(ban);
+      });
+    });
+    client.on("voiceStateUpdate", (oldState, newState) => {
+      instances.filter(i => !!i.onVoiceStateUpdate).map(i => {
+        logger.debug(`[hooks] processing voiceStateUpdate via ${i.name}`);
+        return i.onVoiceStateUpdate(oldState, newState);
+      });
+    });
   }
 
-  restart(name) {
+  restart(name: string) {
+    let x = 5;
     logger.debug(`[hooks] restarting service ${name}...`);
     this.watchdog[name]?.restart();
   }


### PR DESCRIPTION
Right now the hooks are launching too many events in the Discord.js Client class.
This is cumbersome because it makes the order of the events not known.
This pull refactors the hook system so that instead of having multiple events, there
is a single event listener which acts as a broker to dispatch the events in order.