### PR TITLE
feat: design thread-only channels

### DIFF
--- a/src/hooks/linkchannel.ts
+++ b/src/hooks/linkchannel.ts
@@ -1,0 +1,109 @@
+import {
+  GuildMember,
+  Message,
+  NewsChannel,
+  TextBasedChannels,
+  TextChannel,
+  ThreadChannel,
+} from "discord.js";
+import { userMention } from "@discordjs/builders";
+import getUrls from "get-urls";
+import { Hook } from "../lib/hook";
+import { quoteMessage } from "../lib/response";
+import Server from "../lib/server";
+
+/**
+ * Deals with the draconian rules that power our link-based channels, such as #enlaces,
+ * where it is only allowed to post messages that have links, forcing discussions to
+ * happen inside thread channels.
+ *
+ * This hook will do the following:
+ *
+ * - Whenever a message with a link is posted, it will open a thread for that specific
+ *   message, so that people can keep up with the conversation inside the thread for
+ *   that specific message.
+ * - Whenever a message without a link is posted, it will be deleted.
+ */
+export default class LinkChannel implements Hook {
+  name = "link";
+
+  async onMessageCreate(msg: Message): Promise<void> {
+    if (
+      isLinkableChannel(msg.channel) &&
+      isManagedLinkChannel(msg.channel) &&
+      isAcceptableUser(msg.member)
+    ) {
+      return handleMessage(msg);
+    }
+  }
+}
+
+/** We monitor these kinds of channels. */
+type LinkableChannel = TextChannel | NewsChannel;
+
+function isAcceptableUser(gm: GuildMember): boolean {
+  return gm.user && !gm.user.bot;
+}
+
+/** Tests and coerces this channel into an acceptable channel type we monitor. */
+function isLinkableChannel(channel: TextBasedChannels): channel is LinkableChannel {
+  const types = ["GUILD_NEWS", "GUILD_TEXT"];
+  return types.includes(channel.type);
+}
+
+/** Tests whether the given channel should behave as a link-based channel. */
+function isManagedLinkChannel(channel: LinkableChannel) {
+  if (channel.guild) {
+    const server = new Server(channel.guild);
+    const linkables = server.tagbag.tag("linkchannels").get([]);
+    return linkables.includes(channel.id);
+  }
+  return false;
+}
+
+async function handleMessage(msg: Message): Promise<void> {
+  const firstUrl = getFirstLink(msg);
+  if (firstUrl) {
+    /* Message has a link, AOK. */
+    await startThread(msg);
+  } else {
+    if (msg.reference?.messageId) {
+      /* Message references another message, let's try to embed it. */
+      await nestMessage(msg);
+    }
+    /* Sorry, we can't do anything. */
+    await destroyMessage(msg);
+  }
+}
+
+function getFirstLink(msg: Message): string | null {
+  const urls = getUrls(msg.cleanContent);
+  if (urls.size > 0) {
+    return [...urls][0];
+  } else {
+    return null;
+  }
+}
+
+/** Handler when the message is valid and should start a thread. */
+function startThread(msg: Message): Promise<ThreadChannel> {
+  const name = `${msg.id}`;
+  return msg.startThread({ name });
+}
+
+/** Handler when the message was replied to, to try to put the reply in the thread. */
+async function nestMessage(msg: Message): Promise<void> {
+  const references = await msg.fetchReference();
+  if (references.hasThread) {
+    const quote = quoteMessage(msg);
+    await references.thread.send({
+      ...quote,
+      content: `${userMention(msg.author.id)} quiso decir:`,
+    });
+  }
+}
+
+/** Handler when the message is totally not valid and should be disposed. */
+async function destroyMessage(msg: Message): Promise<void> {
+  await msg.delete();
+}

--- a/src/hooks/threadchannel.ts
+++ b/src/hooks/threadchannel.ts
@@ -1,0 +1,55 @@
+import {
+  GuildMember,
+  Message,
+  NewsChannel,
+  TextBasedChannels,
+  TextChannel,
+  User,
+} from "discord.js";
+import { Hook } from "../lib/hook";
+import Server from "../lib/server";
+
+/**
+ * Whenever a message is posted in a channel, it will open a thread for it.
+ * Handles the draconian rules that power some channels where communication
+ * should always be managed in threads.
+ */
+export default class ThreadChannelService implements Hook {
+  name = "threads";
+
+  async onMessageCreate(msg: Message): Promise<void> {
+    if (
+      isThreadableChannel(msg.channel) &&
+      isManagedThreadChannel(msg.channel) &&
+      isAcceptableUser(msg.member)
+    ) {
+      await startThread(msg);
+    }
+  }
+}
+
+type ThreadableChannel = TextChannel | NewsChannel;
+
+/** Test if the channel can be managed and coerces into a threadable channel. */
+function isThreadableChannel(channel: TextBasedChannels): channel is ThreadableChannel {
+  return ["GUILD_TEXT", "GUILD_NEWS"].includes(channel.type);
+}
+
+/** Tests whether the given channel should behave as a thread-based channel. */
+function isManagedThreadChannel(channel: ThreadableChannel) {
+  if (channel.guild) {
+    const server = new Server(channel.guild);
+    const linkables = server.tagbag.tag("threadchannels").get([]);
+    return linkables.includes(channel.id);
+  }
+  return false;
+}
+
+function isAcceptableUser(gm: GuildMember): boolean {
+  return gm.user && !gm.user.bot;
+}
+
+async function startThread(msg: Message): Promise<void> {
+  const name = `${msg.id}`;
+  await msg.startThread({ name });
+}


### PR DESCRIPTION
This commit allows channels to be marked as thread-only, either
via a linkchannel or via a threadchannel. In both cases,
communication should be enforced using a thread.

Link channels will only accept messages that contain a link. If
a message that lacks a link is posted, the system will delete it.
This is useful for our links channel.

Thread channels will not make any test: any new message received
will spawn a thread for making comments. This is useful for our
server feedback channel and our showcase channel, to prevent
noise.

<!-- 👋 Thank you for contributing code to this project

To guarantee success for your pull request, use the following template.
Make sure the checklis passes. Otherwise, your pull request may be
rejected. By sending a pull request, you agree you have read this
document, as well as CONTRIBUTING.md and CODE_OF_CONDUCT.md. Thank you! -->

Add your PR description here.

## Checklist

- [ ] Given that this code will have to be maintained by someone else in
      the future that it's not me, my code is clean, concise and it has
      been tested.
- [ ] There is an issue tracking this feature and I've linked to it in my
      PR, where a discussion may have been held, because I'd rather not
      add surprise features without discussing whether they fit or not
      in the project scope before.
- [ ] The files conforming this PR have been formatted with prettier
      so that they follow the code styleguide.
