### PR TITLE
feat: add commands for threads management

### DIFF
--- a/src/interactions/commands/archivar.ts
+++ b/src/interactions/commands/archivar.ts
@@ -1,0 +1,42 @@
+import { CommandInteraction } from "discord.js";
+import { CommandInteractionHandler } from "../../lib/interaction";
+import { createToast } from "../../lib/response";
+
+/**
+ * Archives a thread, as long as the thread was opened by me, or the thread was
+ * started on top of a message of mine. This is useful when the bot starts
+ * automatically a thread using the linkchannel or threadchannel hook, or
+ * whenver someone opens a thread and it gets replied quickly.
+ */
+export default class ArchivarCommand implements CommandInteractionHandler {
+  name = "archivar";
+
+  async handle(event: CommandInteraction): Promise<void> {
+    if (event.channel.isThread()) {
+      const message = await event.channel.fetchStarterMessage();
+      if (event.channel.ownerId === event.user.id || event.user.id === message.author.id) {
+        await event.reply({ embeds: [ARCHIVED], ephemeral: true });
+        await event.channel.setArchived(true, "Pedido mediante el comando /archivar");
+      } else {
+        return event.reply({ embeds: [EXCUSE_NOT_YOUR_THREAD], ephemeral: true });
+      }
+    } else {
+      return event.reply({ embeds: [EXCUSE_NON_THREAD], ephemeral: true });
+    }
+  }
+}
+
+const ARCHIVED = createToast({
+  title: "El hilo se archivará.",
+  severity: "success",
+});
+
+const EXCUSE_NON_THREAD = createToast({
+  title: "Este comando sólo puede ser usado dentro de un hilo.",
+  severity: "error",
+});
+
+const EXCUSE_NOT_YOUR_THREAD = createToast({
+  title: "Este comando sólo puede ser usado en un hilos abiertos a partir de tu mensaje.",
+  severity: "error",
+});

--- a/src/interactions/commands/renombrar.ts
+++ b/src/interactions/commands/renombrar.ts
@@ -1,0 +1,44 @@
+import { CommandInteraction } from "discord.js";
+import { CommandInteractionHandler } from "../../lib/interaction";
+import { createToast } from "../../lib/response";
+
+/**
+ * Renames a thread, as long as the thread was opened for a message of yours.
+ * For instance, if the bot opens a thread on a message that I've sent, using
+ * the `linkchannel` or the `threadchannel` hooks, it will have an ugly name.
+ * Or maybe I don't like the name used by someone when opened a thread on top
+ * of my message.
+ */
+export default class RenombrarCommand implements CommandInteractionHandler {
+  name = "renombrar";
+
+  async handle(event: CommandInteraction): Promise<void> {
+    if (event.channel.isThread()) {
+      const message = await event.channel.fetchStarterMessage();
+      if (event.channel.ownerId === event.user.id || event.user.id === message.author.id) {
+        const newName = event.options.getString("titulo", true);
+        await event.channel.setName(newName, "Pedido mediante el comando /renombrar");
+        return event.reply({ embeds: [RENAMED], ephemeral: true });
+      } else {
+        return event.reply({ embeds: [EXCUSE_NOT_YOUR_THREAD], ephemeral: true });
+      }
+    } else {
+      return event.reply({ embeds: [EXCUSE_NON_THREAD], ephemeral: true });
+    }
+  }
+}
+
+const RENAMED = createToast({
+  title: "Hilo renombrado correctamente.",
+  severity: "success",
+});
+
+const EXCUSE_NON_THREAD = createToast({
+  title: "Este comando sólo puede ser usado dentro de un hilo.",
+  severity: "error",
+});
+
+const EXCUSE_NOT_YOUR_THREAD = createToast({
+  title: "Este comando sólo puede ser usado en un hilos abiertos a partir de tu mensaje.",
+  severity: "error",
+});


### PR DESCRIPTION
This commit will add the following commands:

- /archivar can be used to archive a thread.
- /renombrar can be used to change the name of a thread.

In both cases, it is required that either the thread was created
by the author issuing the command, or that the thread was
started on top of a message created by the person issuing the
command.

This is useful when someone replies to your message, or when
the bot spawns a thread starting from a message you have
created.

<!-- 👋 Thank you for contributing code to this project

To guarantee success for your pull request, use the following template.
Make sure the checklis passes. Otherwise, your pull request may be
rejected. By sending a pull request, you agree you have read this
document, as well as CONTRIBUTING.md and CODE_OF_CONDUCT.md. Thank you! -->

Add your PR description here.

## Checklist

- [ ] Given that this code will have to be maintained by someone else in
      the future that it's not me, my code is clean, concise and it has
      been tested.
- [ ] There is an issue tracking this feature and I've linked to it in my
      PR, where a discussion may have been held, because I'd rather not
      add surprise features without discussing whether they fit or not
      in the project scope before.
- [ ] The files conforming this PR have been formatted with prettier
      so that they follow the code styleguide.
