### PR TITLE
refactor: new mass-requirer

### DIFF
--- a/docs/development/interactions.md
+++ b/docs/development/interactions.md
@@ -1,0 +1,57 @@
+---
+layout: default
+title: Interactions
+nav_order: 2
+parent: Desarrollo
+---
+
+## Cómo funcionan las interacciones
+
+Las interacciones es el sistema que Discord desea que los bots usen para comportarse en servidores de aquí a futuro.
+
+Existen en este momento cuatro tipo de interacciones. Cada tipo de interacción se dispara de una forma concreta, pero en todos los casos se traduce en un evento que recibe la aplicación, con toda la información referente a esa interacción (quién la realizó y dónde, el tipo de interacción concreta que se ha disparado, y posibles parámetros que puede tener ese tipo de interacción). Los cuatro tipos de interacción que hay ahora mismo son:
+
+* Comandos: un usuario dispara una interacción de este tipo escribiendo un barra-comando en el chat.
+* Menús contextuales: se disparan haciendo clic derecho sobre un mensaje o un guild member y ejecutando una opción desde el menú.
+* Botones: se disparan pulsando un botón.
+* Menús de selección: se disparan desplegando un menú de selección en un mensaje y realizando una selección.
+
+## Cómo funcionan las interacciones en Makibot
+
+Como todas las interacciones se gestionan en Discord.js desde el mismo evento, y viendo los antecedentes que hay en el sistema hook, desde el primer momento las interacciones en Makibot están concebidas como clases independientes que implementan una lógica de negocio y que se identifican de algún modo.
+
+Un manager (InteractionManager) se ocupará de recibir de forma global todas las interacciones y despacharlas, enviándolas a la clase concreta que corresponda en cada caso.
+
+Para crear una interacción, hay que depositar en alguna de las subcarpetas del directorio `src/interactions` un archivo que exporte una clase. En función del tipo de interacción que se vaya a definir, hay que dejarla en una subcarpeta u otra:
+
+* Los comandos van en `src/interactions/commands`.
+* Los menús contextuales van en `src/interactions/menus`.
+* Los botones van en `src/interactions/buttons`.
+* Los menús de selección van en `src/interactions/selects`.
+
+Dentro de cada archivo hay que exportar una clase que debe extender a alguna de las cuatro clases superiores:
+
+* Los comandos se procesan con clases que extienden `CommandInteractionHandler`.
+* Los menús contextuales se procesan con clases que extienden `ContextMenuInteractionHandler`.
+* Los botones se procesan con clases que extienden `ButtonInteractionHandler`.
+* Los menús de selección se procesan con clases que extienden `SelectMenuInteractionHandler`.
+
+Estas interfaces están definidas en `src/lib/interactions`, y como se ve, implementan todas una función llamada `handle`. La diferencia está en el primer parámetro, que siempre será la propia interacción recibida, pero que en cada caso será del tipo que corresponda:
+
+```ts
+export interface CommandInteractionHandler extends BaseInteractionHandler {
+  handle(event: CommandInteraction): Promise<void>;
+}
+
+export interface ContextMenuInteractionHandler extends BaseInteractionHandler {
+  handle(event: ContextMenuInteraction): Promise<void>;
+}
+
+export interface ButtonInteractionHandler extends BaseInteractionHandler {
+  handle(event: ButtonInteraction): Promise<void>;
+}
+
+export interface SelectMenuInteractionHandler extends BaseInteractionHandler {
+  handle(event: SelectMenuInteraction): Promise<void>;
+}
+```

--- a/src/Makibot.ts
+++ b/src/Makibot.ts
@@ -7,7 +7,7 @@ import AntiRaid from "./lib/antiraid";
 import { HookManager } from "./lib/hook";
 import { KarmaDatabase, openKarmaDatabase } from "./lib/karma/database";
 import { SettingProvider } from "./lib/provider";
-import { installCommandInteractionHandler } from "./lib/interaction";
+import { InteractionManager } from "./lib/interaction";
 import { ModerationRepository, newModRepository } from "./lib/modlog/database";
 import logger from "./lib/logger";
 
@@ -18,12 +18,13 @@ export default class Makibot extends Client {
 
   private _provider: SettingProvider;
 
-  private _manager: HookManager;
+  private _hooks: HookManager;
+  private _interactions: InteractionManager;
 
   private _modrepo: ModerationRepository;
 
   public get manager(): HookManager {
-    return this._manager;
+    return this._hooks;
   }
 
   public constructor() {
@@ -65,8 +66,8 @@ export default class Makibot extends Client {
             .then((db) => (this._karma = db));
         })
         .then(() => {
-          this._manager = new HookManager(path.join(__dirname, "hooks"), this);
-          installCommandInteractionHandler(path.join(__dirname, "interactions"), this);
+          this._hooks = new HookManager(path.join(__dirname, "hooks"), this);
+          this._interactions = new InteractionManager(path.join(__dirname, "interactions"), this);
         })
         .then(() => {
           // Init the antiraid engine.

--- a/src/interactions/buttons/applyModRequest.ts
+++ b/src/interactions/buttons/applyModRequest.ts
@@ -1,12 +1,12 @@
 import { ButtonInteraction, MessageActionRow, MessageButton, TextBasedChannels } from "discord.js";
-import { ComponentInteractionHandler } from "../../lib/interaction";
+import { ButtonInteractionHandler } from "../../lib/interaction";
 import { getReportReason, ModReport } from "../../lib/modlog/report";
 import Server from "../../lib/server";
 import applyWarn from "../../lib/warn";
 import { userMention } from "@discordjs/builders";
 import { createToast } from "../../lib/response";
 
-export default class CancelModRequest implements ComponentInteractionHandler {
+export default class CancelModRequest implements ButtonInteractionHandler {
   name = "applyModRequest";
 
   async handle(event: ButtonInteraction): Promise<void> {

--- a/src/interactions/buttons/cancelModRequest.ts
+++ b/src/interactions/buttons/cancelModRequest.ts
@@ -1,8 +1,8 @@
 import { ButtonInteraction } from "discord.js";
-import { ComponentInteractionHandler } from "../../lib/interaction";
+import { ButtonInteractionHandler } from "../../lib/interaction";
 import Server from "../../lib/server";
 
-export default class CancelModRequest implements ComponentInteractionHandler {
+export default class CancelModRequest implements ButtonInteractionHandler {
   name = "cancelModRequest";
 
   async handle(event: ButtonInteraction): Promise<void> {

--- a/src/interactions/buttons/deleteMessageModRequest.ts
+++ b/src/interactions/buttons/deleteMessageModRequest.ts
@@ -1,9 +1,9 @@
 import { ButtonInteraction, TextBasedChannels } from "discord.js";
-import { ComponentInteractionHandler } from "../../lib/interaction";
+import { ButtonInteractionHandler } from "../../lib/interaction";
 import { ModReport } from "../../lib/modlog/report";
 import Server from "../../lib/server";
 
-export default class CancelModRequest implements ComponentInteractionHandler {
+export default class CancelModRequest implements ButtonInteractionHandler {
   name = "deleteMessageModRequest";
 
   async handle(event: ButtonInteraction): Promise<void> {

--- a/src/interactions/buttons/karma.ts
+++ b/src/interactions/buttons/karma.ts
@@ -1,10 +1,10 @@
 import { ButtonInteraction, MessageActionRow } from "discord.js";
-import { ComponentInteractionHandler } from "../../lib/interaction";
+import { ButtonInteractionHandler } from "../../lib/interaction";
 import { createKarmaToast } from "../../lib/karma";
 import Member from "../../lib/member";
 import { getExplainButton } from "./karmaExplain";
 
-export default class KarmaButton implements ComponentInteractionHandler {
+export default class KarmaButton implements ButtonInteractionHandler {
   name = "karma_button";
 
   async handle(event: ButtonInteraction): Promise<void> {

--- a/src/interactions/buttons/karmaExplain.ts
+++ b/src/interactions/buttons/karmaExplain.ts
@@ -1,5 +1,5 @@
 import { ButtonInteraction, MessageButton } from "discord.js";
-import { ComponentInteractionHandler } from "../../lib/interaction";
+import { ButtonInteractionHandler } from "../../lib/interaction";
 import { createToast } from "../../lib/response";
 
 const TEXT = `
@@ -40,7 +40,7 @@ export function getExplainButton(): MessageButton {
   });
 }
 
-export default class KarmaButton implements ComponentInteractionHandler {
+export default class KarmaButton implements ButtonInteractionHandler {
   name = "karma_explain_button";
 
   async handle(event: ButtonInteraction): Promise<void> {

--- a/src/interactions/buttons/keepMessageModRequest.ts
+++ b/src/interactions/buttons/keepMessageModRequest.ts
@@ -1,7 +1,7 @@
 import { ButtonInteraction } from "discord.js";
-import { ComponentInteractionHandler } from "../../lib/interaction";
+import { ButtonInteractionHandler } from "../../lib/interaction";
 
-export default class CancelModRequest implements ComponentInteractionHandler {
+export default class CancelModRequest implements ButtonInteractionHandler {
   name = "keepMessageModRequest";
 
   async handle(event: ButtonInteraction): Promise<void> {

--- a/src/interactions/buttons/proposeModRequest.ts
+++ b/src/interactions/buttons/proposeModRequest.ts
@@ -1,10 +1,10 @@
 import { ButtonInteraction } from "discord.js";
-import { ComponentInteractionHandler } from "../../lib/interaction";
+import { ButtonInteractionHandler } from "../../lib/interaction";
 import { ReportModlogEvent } from "../../lib/modlog";
 import { ModReport } from "../../lib/modlog/report";
 import Server from "../../lib/server";
 
-export default class ProposeModRequest implements ComponentInteractionHandler {
+export default class ProposeModRequest implements ButtonInteractionHandler {
   name = "proposeModRequest";
 
   async handle(event: ButtonInteraction): Promise<void> {

--- a/src/interactions/buttons/roles.ts
+++ b/src/interactions/buttons/roles.ts
@@ -1,8 +1,8 @@
 import { ButtonInteraction } from "discord.js";
-import { ComponentInteractionHandler } from "../../lib/interaction";
+import { ButtonInteractionHandler } from "../../lib/interaction";
 import { createRolesMessage } from "../../lib/makigas/roles";
 
-export default class RolesButton implements ComponentInteractionHandler {
+export default class RolesButton implements ButtonInteractionHandler {
   name = "roles_button";
 
   async handle(event: ButtonInteraction): Promise<void> {

--- a/src/interactions/selects/modMenuAction.ts
+++ b/src/interactions/selects/modMenuAction.ts
@@ -1,10 +1,10 @@
 import { MessageComponentInteraction, SelectMenuInteraction } from "discord.js";
-import { ComponentInteractionHandler } from "../../lib/interaction";
+import { SelectMenuInteractionHandler } from "../../lib/interaction";
 import { ModReport, renderMenuComponents } from "../../lib/modlog/report";
 import { createToast } from "../../lib/response";
 import Server from "../../lib/server";
 
-export default class ModMenuAction implements ComponentInteractionHandler {
+export default class ModMenuAction implements SelectMenuInteractionHandler {
   name = "modmenu_action";
 
   async handle(event: SelectMenuInteraction): Promise<void> {

--- a/src/interactions/selects/modMenuAlert.ts
+++ b/src/interactions/selects/modMenuAlert.ts
@@ -1,10 +1,10 @@
 import { MessageComponentInteraction, SelectMenuInteraction } from "discord.js";
-import { ComponentInteractionHandler } from "../../lib/interaction";
+import { SelectMenuInteractionHandler } from "../../lib/interaction";
 import { ModReport, renderMenuComponents } from "../../lib/modlog/report";
 import { createToast } from "../../lib/response";
 import Server from "../../lib/server";
 
-export default class ModMenuAlert implements ComponentInteractionHandler {
+export default class ModMenuAlert implements SelectMenuInteractionHandler {
   name = "modmenu_alert";
 
   async handle(event: SelectMenuInteraction): Promise<void> {

--- a/src/interactions/selects/modMenuReason.ts
+++ b/src/interactions/selects/modMenuReason.ts
@@ -1,10 +1,10 @@
 import { MessageComponentInteraction, SelectMenuInteraction } from "discord.js";
-import { ComponentInteractionHandler } from "../../lib/interaction";
+import { SelectMenuInteractionHandler } from "../../lib/interaction";
 import { ModReport, renderMenuComponents } from "../../lib/modlog/report";
 import { createToast } from "../../lib/response";
 import Server from "../../lib/server";
 
-export default class ModMenuReason implements ComponentInteractionHandler {
+export default class ModMenuReason implements SelectMenuInteractionHandler {
   name = "modmenu_reason";
 
   async handle(event: SelectMenuInteraction): Promise<void> {

--- a/src/interactions/selects/setServerRole.ts
+++ b/src/interactions/selects/setServerRole.ts
@@ -1,12 +1,12 @@
-import { MessageComponentInteraction, SelectMenuInteraction } from "discord.js";
-import { ComponentInteractionHandler } from "../../lib/interaction";
+import { SelectMenuInteraction } from "discord.js";
+import { SelectMenuInteractionHandler } from "../../lib/interaction";
 import { createRolesMessage, ROLE_DEFINITIONS } from "../../lib/makigas/roles";
 
 function difference(a: string[], b: string[]): string[] {
   return a.filter((i) => !b.includes(i));
 }
 
-export default class ModMenuAlert implements ComponentInteractionHandler {
+export default class ModMenuAlert implements SelectMenuInteractionHandler {
   name = "Set server role";
 
   async handle(event: SelectMenuInteraction): Promise<void> {

--- a/src/lib/utils/functional.ts
+++ b/src/lib/utils/functional.ts
@@ -1,0 +1,5 @@
+export type Index<T> = { [key: string]: T };
+
+export function mapBy<R, K extends keyof R>(items: R[], key: K): { [k: string]: R } {
+  return Object.fromEntries(items.map((item) => [item[key], item]));
+}

--- a/src/lib/utils/loader.ts
+++ b/src/lib/utils/loader.ts
@@ -1,0 +1,39 @@
+import requireAll from "require-all";
+
+type MightBeModule = {
+  default?: unknown;
+};
+
+/**
+ * requireAll() will require ES Modules that export default something as
+ * an object where the default exported symbol is inside an object with
+ * the key "default". This function will coerce something required by
+ * requireAll() so that default exports can be properly used as if they
+ * were exported using the classic module.exports system.
+ *
+ * @param module a required module that might or might not be an ES Module.
+ * @returns something that it is not an ES Module.
+ */
+function coerceModules(module: MightBeModule): unknown {
+  if (module.default && typeof module.default === "function") {
+    return module.default;
+  }
+  return module;
+}
+
+/**
+ * Mass-require all the files in the given directory. Internally uses
+ * requireAll, but this function already handles the case of ES Modules
+ * being present in the directory.
+ *
+ * @param path the path where the modules have to be loaded
+ * @returns an array with all the required modules from this directory
+ */
+export function requireAllModules<T>(path: string): unknown[] {
+  const required = requireAll({
+    dirname: path,
+    filter: /^([^.].*)\.[jt]s$/,
+    resolve: coerceModules,
+  });
+  return Object.values<T>(required);
+}


### PR DESCRIPTION
The purpose of this PR is to refactor calls to `requireAll` in both the hook loading system and the interaction loading system to make them easier to understand. It is the logical next step after commit 94b4b54f7121242e8441ae4b19c595aff46379a4, and it is required in order to do some things that I have planned.

Things for this PR:

* A new mass-loader that wraps `requireAll`, allowing to be reused both in the hooks loader and the interaction handler loader. It will use new features from TypeScript 4.4, such as `unknown` so that I can play with the type system and make it better without some errors that I sometimes have when I do weird things with my hooks.

* Also, document how the interaction handlers work in the API docs.